### PR TITLE
don't use system expat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
           path: |
             Fcitx5-${{ matrix.arch }}.dmg
 
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+
   release:
     needs: build
     if: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         if: ${{ matrix.arch == 'x86_64' }}
         run: |
           brew install \
+            expat \
             fmt \
             extra-cmake-modules \
             libxkbcommon \
@@ -69,6 +70,7 @@ jobs:
             ninja
           pip install "dmgbuild[badge_icons]"
           arm-brew-install \
+            expat \
             fmt \
             gettext \
             libxkbcommon \
@@ -80,7 +82,7 @@ jobs:
 
       - name: Build
         run: |
-          PKG_CONFIG_PATH=${{ matrix.homebrew_prefix }}/lib/pkgconfig cmake -B build -G Ninja \
+          cmake -B build -G Ninja \
             -DCMAKE_Swift_COMPILER=`which swiftc` \
             -DCMAKE_FIND_ROOT_PATH=${{ matrix.homebrew_prefix }} \
             -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
             expat \
             fmt \
             gettext \
+            xkeyboardconfig \
             libxkbcommon \
             iso-codes \
             json-c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
             libxkbcommon \
             iso-codes \
             json-c \
-            openssl@3 \
             libuv
           cp -f /usr/local/bin/msgfmt /opt/homebrew/bin
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
     set(HOMEBREW_PATH "/usr/local")
 endif()
 
-set(ENV{PKG_CONFIG_PATH} "${HOMEBREW_PATH}/lib/pkgconfig:${HOMEBREW_PATH}/opt/expat/lib/pkgconfig")
+set(ENV{PKG_CONFIG_PATH} "${HOMEBREW_PATH}/lib/pkgconfig:${HOMEBREW_PATH}/share/pkgconfig:${HOMEBREW_PATH}/opt/expat/lib/pkgconfig")
 
 option(ENABLE_TEST "" OFF)
 option(ENABLE_COVERAGE "" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,18 @@ include(AddSwift)
 
 set(CMAKE_CXX_STANDARD 17)
 
+if(NOT CMAKE_OSX_ARCHITECTURES)
+    set(CMAKE_OSX_ARCHITECTURES "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+endif()
+
 if(CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
     add_definitions(-target "arm64-apple-macos11")
+    set(HOMEBREW_PATH "/opt/homebrew")
+else()
+    set(HOMEBREW_PATH "/usr/local")
 endif()
+
+set(ENV{PKG_CONFIG_PATH} "${HOMEBREW_PATH}/lib/pkgconfig:${HOMEBREW_PATH}/opt/expat/lib/pkgconfig")
 
 option(ENABLE_TEST "" OFF)
 option(ENABLE_COVERAGE "" OFF)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cross build from Intel to Apple Silicon is performed in [CI](.github/workflows/c
 
 ### Install dependencies
 ```sh
-brew install cmake ninja extra-cmake-modules gettext fmt libuv libxkbcommon iso-codes json-c
+brew install cmake ninja extra-cmake-modules gettext expat fmt libuv libxkbcommon iso-codes json-c
 ```
 
 ### Build with CMake


### PR DESCRIPTION
On my M1 mac, pkgconfig locates expat.h under `/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include` which also contains headers of C standard lib, which shouldn't be searched before headers of C++ standard lib.