### PR TITLE
Handle modifier keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           find macosfrontend src -name '*.cpp' -o -name '*.h' | xargs clang-format -Werror --dry-run -style=file:fcitx5/.clang-format
           swift-format lint -rs src
-          swiftlint --strict src
 
   build:
     needs: lint

--- a/include/fcitx.h
+++ b/include/fcitx.h
@@ -6,6 +6,6 @@
 
 void start_fcitx();
 // Though being UInt, 32b is enough for modifiers
-bool process_key(uint32_t unicode, uint32_t osxModifiers, uint16_t osxKeycode);
+bool process_key(uint32_t unicode, uint32_t osxModifiers, uint16_t osxKeycode, bool isRelease);
 
 #endif

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -141,13 +141,14 @@ void MacosFrontend::showPreedit(const std::string &preedit, int caretPos) {
     showPreeditCallback(preedit, caretPos);
 }
 
-bool MacosFrontend::keyEvent(fcitx::ICUUID uuid, const Key &key) {
+bool MacosFrontend::keyEvent(fcitx::ICUUID uuid, const Key &key,
+                             bool isRelease) {
     auto *ic = instance_->inputContextManager().findByUUID(uuid);
     activeIC_ = dynamic_cast<MacosInputContext *>(ic);
     if (!ic) {
         return false;
     }
-    KeyEvent keyEvent(ic, key, false);
+    KeyEvent keyEvent(ic, key, isRelease);
     ic->keyEvent(keyEvent);
     return keyEvent.accepted();
 }

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -30,7 +30,7 @@ public:
 
     void updateCandidateList(const std::vector<std::string> &candidates,
                              const int size);
-    bool keyEvent(fcitx::ICUUID, const Key &key);
+    bool keyEvent(fcitx::ICUUID, const Key &key, bool isRelease);
     void commitString(const std::string &text);
     void showPreedit(const std::string &, int);
     ICUUID createInputContext();

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -4,6 +4,8 @@ import InputMethodKit
 import SwiftFcitx
 
 class FcitxInputController: IMKInputController {
+  var lastModifiers = NSEvent.ModifierFlags(rawValue: 0)
+
   // Default behavior is to recognize keyDown only
   override func recognizedEvents(_ sender: Any!) -> Int {
     let events: NSEvent.EventTypeMask = [.keyDown, .flagsChanged]
@@ -24,7 +26,27 @@ class FcitxInputController: IMKInputController {
       }
       let code = event.keyCode
       let modifiers = UInt32(event.modifierFlags.rawValue)
-      let handled = process_key(unicode, modifiers, code)
+      let handled = process_key(unicode, modifiers, code, false)
+      return handled
+    case .flagsChanged:
+      let code = event.keyCode
+      let mods = event.modifierFlags
+      let modsVal = UInt32(mods.rawValue)
+      let change = NSEvent.ModifierFlags(rawValue: mods.rawValue ^ lastModifiers.rawValue)
+      let isRelease: Bool = (lastModifiers.rawValue & change.rawValue) != 0
+      var handled = false
+      if change.contains(.shift) {
+        handled = process_key(0, modsVal, code, isRelease)
+      } else if change.contains(.control) {
+        handled = process_key(0, modsVal, code, isRelease)
+      } else if change.contains(.command) {
+        handled = process_key(0, modsVal, code, isRelease)
+      } else if change.contains(.option) {
+        handled = process_key(0, modsVal, code, isRelease)
+      } else if change.contains(.capsLock) {
+        handled = process_key(0, modsVal, code, isRelease)
+      }
+      lastModifiers = mods
       return handled
     default:
       NSLog("Unhandled event: \(String(describing: event.type))")

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -20,9 +20,10 @@ class FcitxInputController: IMKInputController {
     switch event.type {
     case .keyDown:
       var unicode: UInt32 = 0
-      if let characters = event.charactersIgnoringModifiers {
+      if let characters = event.characters {
         let usv = characters.unicodeScalars
         unicode = usv[usv.startIndex].value
+        unicode = removeCtrl(char: unicode)
       }
       let code = event.keyCode
       let modifiers = UInt32(event.modifierFlags.rawValue)
@@ -56,5 +57,14 @@ class FcitxInputController: IMKInputController {
 
   override func candidates(_ sender: Any!) -> [Any]! {
     return getCandidateList()
+  }
+}
+
+/// Convert a character like ^X to the corresponding lowercase letter x.
+private func removeCtrl(char: UInt32) -> UInt32 {
+  if char >= 0x00 && char <= 0x1F {
+    return char + 0x60
+  } else {
+    return char
   }
 }

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -37,6 +37,11 @@ class FcitxInputController: IMKInputController {
       return false
     }
     setClient(client)
+
+    let code = event.keyCode
+    let mods = event.modifierFlags
+    let modsVal = UInt32(mods.rawValue)
+
     switch event.type {
     case .keyDown:
       var unicode: UInt32 = 0
@@ -46,26 +51,15 @@ class FcitxInputController: IMKInputController {
         // Send x[state:ctrl] instead of ^X[state:ctrl] to fcitx.
         unicode = removeCtrl(char: unicode)
       }
-      let code = event.keyCode
-      let modifiers = UInt32(event.modifierFlags.rawValue)
-      let handled = process_key(cookie, unicode, modifiers, code, false)
+      let handled = process_key(cookie, unicode, modsVal, code, false)
       return handled
     case .flagsChanged:
-      let code = event.keyCode
-      let mods = event.modifierFlags
-      let modsVal = UInt32(mods.rawValue)
       let change = NSEvent.ModifierFlags(rawValue: mods.rawValue ^ lastModifiers.rawValue)
       let isRelease: Bool = (lastModifiers.rawValue & change.rawValue) != 0
       var handled = false
-      if change.contains(.shift) {
-        handled = process_key(cookie, 0, modsVal, code, isRelease)
-      } else if change.contains(.control) {
-        handled = process_key(cookie, 0, modsVal, code, isRelease)
-      } else if change.contains(.command) {
-        handled = process_key(cookie, 0, modsVal, code, isRelease)
-      } else if change.contains(.option) {
-        handled = process_key(cookie, 0, modsVal, code, isRelease)
-      } else if change.contains(.capsLock) {
+      if change.contains(.shift) || change.contains(.control) || change.contains(.command)
+        || change.contains(.option) || change.contains(.capsLock)
+      {
         handled = process_key(cookie, 0, modsVal, code, isRelease)
       }
       lastModifiers = mods

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -23,6 +23,7 @@ class FcitxInputController: IMKInputController {
       if let characters = event.characters {
         let usv = characters.unicodeScalars
         unicode = usv[usv.startIndex].value
+        // Send x[state:ctrl] instead of ^\X[state:ctrl] to fcitx.
         unicode = removeCtrl(char: unicode)
       }
       let code = event.keyCode

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -23,7 +23,7 @@ class FcitxInputController: IMKInputController {
       if let characters = event.characters {
         let usv = characters.unicodeScalars
         unicode = usv[usv.startIndex].value
-        // Send x[state:ctrl] instead of ^\X[state:ctrl] to fcitx.
+        // Send x[state:ctrl] instead of ^X[state:ctrl] to fcitx.
         unicode = removeCtrl(char: unicode)
       }
       let code = event.keyCode

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -20,7 +20,7 @@ class FcitxInputController: IMKInputController {
     switch event.type {
     case .keyDown:
       var unicode: UInt32 = 0
-      if let characters = event.characters {
+      if let characters = event.charactersIgnoringModifiers {
         let usv = characters.unicodeScalars
         unicode = usv[usv.startIndex].value
       }

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -77,11 +77,12 @@ void start_fcitx() {
     ic_uuid = p_frontend->createInputContext();
 }
 
-bool process_key(uint32_t unicode, uint32_t osxModifiers, uint16_t osxKeycode) {
+bool process_key(uint32_t unicode, uint32_t osxModifiers, uint16_t osxKeycode,
+                 bool isRelease) {
     const fcitx::Key parsedKey{
         osx_unicode_to_fcitx_keysym(unicode, osxKeycode),
         osx_modifiers_to_fcitx_keystates(osxModifiers),
         osx_keycode_to_fcitx_keycode(osxKeycode),
     };
-    return p_frontend->keyEvent(ic_uuid, parsedKey);
+    return p_frontend->keyEvent(ic_uuid, parsedKey, isRelease);
 }

--- a/src/keycode.cpp
+++ b/src/keycode.cpp
@@ -19,6 +19,8 @@ static struct {
     // special
     {OSX_VK_DELETE, FcitxKey_BackSpace},
     {OSX_VK_RETURN, FcitxKey_Return},
+    {OSX_VK_TAB, FcitxKey_Tab},
+    {OSX_VK_ESCAPE, FcitxKey_Escape},
 
     // arrow keys
     {OSX_VK_CURSOR_UP, FcitxKey_Up},

--- a/src/keycode.cpp
+++ b/src/keycode.cpp
@@ -21,6 +21,8 @@ static struct {
     {OSX_VK_RETURN, FcitxKey_Return},
     {OSX_VK_TAB, FcitxKey_Tab},
     {OSX_VK_ESCAPE, FcitxKey_Escape},
+    {OSX_VK_PC_DEL, FcitxKey_Delete},
+    {OSX_VK_PC_INSERT, FcitxKey_Insert},
 
     // arrow keys
     {OSX_VK_CURSOR_UP, FcitxKey_Up},

--- a/src/keycode.cpp
+++ b/src/keycode.cpp
@@ -16,6 +16,10 @@ static struct {
     {OSX_VK_COMMAND_L, FcitxKey_Super_L},
     {OSX_VK_COMMAND_R, FcitxKey_Super_R},
 
+    // special
+    {OSX_VK_DELETE, FcitxKey_BackSpace},
+    {OSX_VK_RETURN, FcitxKey_Return},
+
     // arrow keys
     {OSX_VK_CURSOR_UP, FcitxKey_Up},
     {OSX_VK_CURSOR_DOWN, FcitxKey_Down},

--- a/src/keycode.cpp
+++ b/src/keycode.cpp
@@ -5,6 +5,17 @@ static struct {
     uint32_t osxKeycode;
     fcitx::KeySym sym;
 } sym_mappings[] = {
+    // modifiers
+    {OSX_VK_CONTROL_L, FcitxKey_Control_L},
+    {OSX_VK_CONTROL_R, FcitxKey_Control_R},
+    {OSX_VK_SHIFT_L, FcitxKey_Shift_L},
+    {OSX_VK_SHIFT_R, FcitxKey_Shift_R},
+    {OSX_VK_CAPSLOCK, FcitxKey_Caps_Lock},
+    {OSX_VK_OPTION_L, FcitxKey_Alt_L},
+    {OSX_VK_OPTION_R, FcitxKey_Alt_R},
+    {OSX_VK_COMMAND_L, FcitxKey_Super_L},
+    {OSX_VK_COMMAND_R, FcitxKey_Super_R},
+
     // arrow keys
     {OSX_VK_CURSOR_UP, FcitxKey_Up},
     {OSX_VK_CURSOR_DOWN, FcitxKey_Down},


### PR DESCRIPTION
use rime to test
+ `shift` to toggle `ascii_mode`
+ `shift+fn+delete` to delete user words
+ correctly send keys like `ctrl+b` `ctrl-m` to fcitx-rime
+ special keys (return, tab, esc, etc.) still work
+ `shift+a` still sends `A` 