### PR TITLE
Fix caret display in client preedit

### DIFF
--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -36,10 +36,9 @@ public:
     void forwardKeyImpl(const ForwardKeyEvent &key) override {}
 
     void updatePreeditImpl() override {
-        auto text = frontend_->instance()->outputFilter(
+        auto preedit = frontend_->instance()->outputFilter(
             this, inputPanel().clientPreedit());
-        auto strPreedit = text.toString();
-        frontend_->showPreedit(strPreedit, text.cursor());
+        frontend_->showPreedit(preedit.toString(), preedit.cursor());
     }
 
     void updateInputPanel() {

--- a/src/fcitx.swift
+++ b/src/fcitx.swift
@@ -42,13 +42,24 @@ public func showCandidatePanel() {
   }
 }
 
-public func showPreedit(_ preedit: String, caretPos: Int) {
+public func showPreedit(_ preedit: String, _ caretPosUtf8: Int) {
   guard let client = globalClient as? IMKTextInput else {
     return
   }
+  // The caretPos argument is specified in UTF-8 bytes.
+  // Convert it to UTF-16.
+  var u8pos = 0
+  var u16pos = 0
+  for ch in preedit {
+    if u8pos == caretPosUtf8 {
+      break
+    }
+    u8pos += ch.utf8.count
+    u16pos += 1
+  }
   client.setMarkedText(
     NSMutableAttributedString(string: preedit),
-    selectionRange: NSRange(location: caretPos, length: 0),
+    selectionRange: NSRange(location: u16pos, length: 0),
     replacementRange: NSRange(location: NSNotFound, length: 0)
   )
 }

--- a/src/fcitx.swift
+++ b/src/fcitx.swift
@@ -47,7 +47,7 @@ public func showPreedit(_ preedit: String, caretPos: Int) {
     return
   }
   client.setMarkedText(
-    preedit,
+    NSMutableAttributedString(string: preedit),
     selectionRange: NSRange(location: caretPos, length: 0),
     replacementRange: NSRange(location: NSNotFound, length: 0)
   )


### PR DESCRIPTION
<img width="121" alt="image" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/23358293/bee8ccf5-22ba-4999-b214-48173156f3d3">

By default, the preedit cursor is fixed to be 0, so make sure to put `PreeditCursorPositionAtBeginning=False` in the conf file.