### PR TITLE
Input method switcher

### DIFF
--- a/include/fcitx-public.h
+++ b/include/fcitx-public.h
@@ -17,4 +17,13 @@ void destroy_input_context(Cookie);
 void focus_in(Cookie);
 void focus_out(Cookie);
 
+// NOTE: It's impossible to use std::vector<std::string> directly
+// until Swift fixes C++ interop.
+std::string input_method_groups() noexcept;
+std::string input_method_list() noexcept;
+void set_current_input_method_group(const char *) noexcept;
+std::string get_current_input_method_group() noexcept;
+void set_current_input_method(const char *) noexcept;
+std::string get_current_input_method() noexcept;
+
 #endif

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -126,26 +126,14 @@ class FcitxInputController: IMKInputController {
   }
 
   @objc func switchGroup(sender: Any?) {
-    // Curiously, the sender is a NSMutableDictionary, and looks like this:
-    // {
-    //     IMKCommandClient = "<IPMDServerClientWrapper: 0x6000002a41e0>";
-    //     IMKCommandMenuItem = "<NSMenuItem: 0x6000018818f0 Other>";
-    //     IMKMenuTitle = Other;
-    // }
-    if let sender = sender as? NSMutableDictionary {
-      if let menuItem = sender["IMKCommandMenuItem"] as? NSMenuItem {
-        let groupName = menuItem.representedObject as! String
-        set_current_input_method_group(groupName)
-      }
+    if let groupName = repObjectIMK(sender) as? String {
+      set_current_input_method_group(groupName)
     }
   }
 
   @objc func switchInputMethod(sender: Any?) {
-    if let sender = sender as? NSMutableDictionary {
-      if let menuItem = sender["IMKCommandMenuItem"] as? NSMenuItem {
-        let imName = menuItem.representedObject as! String
-        set_current_input_method(imName)
-      }
+    if let imName = repObjectIMK(sender) as? String {
+      set_current_input_method(imName)
     }
   }
 }
@@ -157,4 +145,21 @@ private func removeCtrl(char: UInt32) -> UInt32 {
   } else {
     return char
   }
+}
+
+/// Extract the representedObject of the sender of an IMK menu action.
+///
+/// The sender of an IMK menu action is a NSMutableDictionary:
+/// {
+///     IMKCommandClient = "<IPMDServerClientWrapper: 0x6000002a41e0>";
+///     IMKCommandMenuItem = "<NSMenuItem: 0x6000018818f0 Other>";
+///     IMKMenuTitle = Other;
+/// }
+private func repObjectIMK(_ sender: Any?) -> Any? {
+  if let sender = sender as? NSMutableDictionary {
+    if let menuItem = sender["IMKCommandMenuItem"] as? NSMenuItem {
+      return menuItem.representedObject
+    }
+  }
+  return nil
 }

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -83,9 +83,64 @@ class FcitxInputController: IMKInputController {
   }
 
   override func menu() -> NSMenu! {
-    let menu = NSMenu(title: "")
+    let menu = NSMenu()
+
+    // Group switcher
+    let groupNames = String(input_method_groups()).split(separator: "\n")
+    let currentGroup = String(get_current_input_method_group())
+    if groupNames.count > 1 {
+      for groupName in groupNames {
+        let groupName = String(groupName)
+        let item = NSMenuItem(title: groupName, action: #selector(switchGroup), keyEquivalent: "")
+        item.representedObject = groupName
+        if groupName == currentGroup {
+          item.state = .on
+        }
+        menu.addItem(item)
+      }
+      menu.addItem(NSMenuItem.separator())
+    }
+
+    // Input method switcher
+    let inputMethods = String(input_method_list()).split(separator: "\n")
+    let currentIM = String(get_current_input_method())
+    for inputMethod in inputMethods {
+      let imName = String(inputMethod)
+      let item = NSMenuItem(title: imName, action: #selector(switchInputMethod), keyEquivalent: "")
+      item.representedObject = imName
+      if inputMethod == currentIM {
+        item.state = .on
+      }
+      menu.addItem(item)
+    }
+    menu.addItem(NSMenuItem.separator())
+
     menu.addItem(withTitle: "About Fcitx5 macOS", action: #selector(about(_:)), keyEquivalent: "")
     return menu
+  }
+
+  @objc func switchGroup(sender: Any) {
+    // Curiously, the sender is a NSMutableDictionary, and looks like this:
+    // {
+    //     IMKCommandClient = "<IPMDServerClientWrapper: 0x6000002a41e0>";
+    //     IMKCommandMenuItem = "<NSMenuItem: 0x6000018818f0 Other>";
+    //     IMKMenuTitle = Other;
+    // }
+    if let sender = sender as? NSMutableDictionary {
+      if let menuItem = sender["IMKCommandMenuItem"] as? NSMenuItem {
+        let groupName = menuItem.representedObject as! String
+        set_current_input_method_group(groupName)
+      }
+    }
+  }
+
+  @objc func switchInputMethod(sender: Any?) {
+    if let sender = sender as? NSMutableDictionary {
+      if let menuItem = sender["IMKCommandMenuItem"] as? NSMenuItem {
+        let imName = menuItem.representedObject as! String
+        set_current_input_method(imName)
+      }
+    }
   }
 }
 

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -102,13 +102,19 @@ class FcitxInputController: IMKInputController {
     }
 
     // Input method switcher
-    let inputMethods = String(input_method_list()).split(separator: "\n")
+    let inputMethodPairs = String(input_method_list()).split(separator: "\n")
     let currentIM = String(get_current_input_method())
-    for inputMethod in inputMethods {
-      let imName = String(inputMethod)
-      let item = NSMenuItem(title: imName, action: #selector(switchInputMethod), keyEquivalent: "")
+    for inputMethodPair in inputMethodPairs {
+      let parts = inputMethodPair.split(separator: ":", maxSplits: 1)
+      let imName = String(parts[0])
+      let nativeName = String(parts[1])
+      let item = NSMenuItem(
+        title: nativeName,
+        action: #selector(switchInputMethod),
+        keyEquivalent: ""
+      )
       item.representedObject = imName
-      if inputMethod == currentIM {
+      if imName == currentIM {
         item.state = .on
       }
       menu.addItem(item)

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -119,7 +119,7 @@ class FcitxInputController: IMKInputController {
     return menu
   }
 
-  @objc func switchGroup(sender: Any) {
+  @objc func switchGroup(sender: Any?) {
     // Curiously, the sender is a NSMutableDictionary, and looks like this:
     // {
     //     IMKCommandClient = "<IPMDServerClientWrapper: 0x6000002a41e0>";

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -196,7 +196,7 @@ std::string input_method_groups() noexcept {
         for (const auto &g : groups) {
             ss << g + "\n";
         }
-        return ss.str();
+        return std::move(ss).str();
     });
 }
 

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -203,9 +203,18 @@ std::string input_method_groups() noexcept {
 std::string input_method_list() noexcept {
     return with_fcitx<std::string>([](Fcitx &fcitx) noexcept {
         std::stringstream ss;
-        auto group = fcitx.instance()->inputMethodManager().currentGroup();
+        auto &imMgr = fcitx.instance()->inputMethodManager();
+        auto group = imMgr.currentGroup();
         for (const auto &im : group.inputMethodList()) {
-            ss << im.name() + "\n";
+            auto entry = imMgr.entry(im.name());
+            if (!entry)
+                continue;
+            std::string displayName = entry->nativeName();
+            if (displayName == "")
+                displayName = entry->name();
+            if (displayName == "")
+                displayName = entry->uniqueName();
+            ss << im.name() << ":" << displayName + "\n";
         }
         return std::move(ss).str();
     });

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -79,7 +79,6 @@ void Fcitx::setupInstance() {
     auto &addonMgr = instance_->addonManager();
     addonMgr.registerDefaultLoader(&staticAddons);
     instance_->initialize();
-    instance_->enumerate(true);
 }
 
 void Fcitx::setupFrontend() {

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -209,11 +209,11 @@ std::string input_method_list() noexcept {
             auto entry = imMgr.entry(im.name());
             if (!entry)
                 continue;
-            std::string displayName = entry->nativeName();
-            if (displayName == "")
-                displayName = entry->name();
-            if (displayName == "")
-                displayName = entry->uniqueName();
+            std::string displayName =
+                entry->nativeName() != ""   ? entry->nativeName()
+                : entry->name() != ""       ? entry->name()
+                : entry->uniqueName() != "" ? entry->uniqueName()
+                                            : im.name();
             ss << im.name() << ":" << displayName + "\n";
         }
         return std::move(ss).str();

--- a/src/fcitx.h
+++ b/src/fcitx.h
@@ -21,6 +21,7 @@ public:
     void exit();
     void schedule(std::function<void()>);
 
+    fcitx::Instance *instance();
     fcitx::AddonManager &addonMgr();
     fcitx::AddonInstance *addon(const std::string &name);
     fcitx::MacosFrontend *macosfrontend();


### PR DESCRIPTION
Example profile:
```
[Groups/0]
Name=Main
Default Layout=us
DefaultIM=pinyin

[Groups/0/Items/0]
Name=rime
Layout=us

[Groups/0/Items/1]
Name=pinyin
Layout=us

[Groups/1]
Name=Other
Default Layout=us
DefaultIM=shuangpin

[Groups/1/Items/0]
Name=shuangpin
Layout=us

[Groups/1/Items/1]
Name=rime
Layout=us

[GroupOrder]
0=Main
1=Other
```

Result:
<img width="185" alt="image" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/23358293/c6dcfe01-a224-4649-aef1-fad707cb8476">

<img width="189" alt="image" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/23358293/c2724775-d2b9-42f0-9192-80d05cd885ca">

The first section (group switcher) will be hidden if there is only one group.
