### PR TITLE
Remove unnecessary panel display

### DIFF
--- a/src/fcitx.h
+++ b/src/fcitx.h
@@ -10,10 +10,10 @@
 #include "webview_candidate_window.hpp"
 
 enum class PanelShowFlag : int {
-    HasAuxUp,
-    HasAuxDown,
-    HasPreedit,
-    HasCandidates
+    HasAuxUp = 1,
+    HasAuxDown = 1 << 1,
+    HasPreedit = 1 << 2,
+    HasCandidates = 1 << 3
 };
 
 using PanelShowFlags = fcitx::Flags<PanelShowFlag>;

--- a/src/fcitx.h
+++ b/src/fcitx.h
@@ -51,7 +51,7 @@ private:
         if (condition)
             panelShow_ |= flag;
         else
-            panelShow_.unset(flag);
+            panelShow_ = panelShow_.unset(flag);
     }
 
     std::unique_ptr<fcitx::Instance> instance_;


### PR DESCRIPTION
My fault. PanelShowFlags was not properly cleared, so every keystroke will show the candidate window.

This also fixes the cmd-v lag. Probable cause:
- cmd-v → f5m: f5m rejects it, but also initiates an async panel show (it won't after this PR)
- cmd-v → program: program initiates paste
- async panel show triggers `client.attributes` and they clash