### PR TITLE
feat(config): Input method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,3 +74,6 @@ add_subdirectory(dmg)
 
 option(BUILD_PREVIEW "" OFF)
 add_subdirectory(fcitx5-webview)
+
+enable_testing()
+add_subdirectory(tests)

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -16,8 +16,8 @@
   <string>org.fcitx.inputmethod.Fcitx5_Connection</string>
   <key>InputMethodServerControllerClass</key>
   <string>Fcitx5.FcitxInputController</string>
-  <key>LSBackgroundOnly</key>
-  <true/>
+  <key>LSUIElement</key>
+  <string>1</string>
   <key>tsInputMethodCharacterRepertoireKey</key>
   <array>
     <string>Latn</string>

--- a/src/config/config-public.h
+++ b/src/config/config-public.h
@@ -20,6 +20,5 @@ std::string getConfig(const char *uri);
 /// This function applies jsonPatch to the current "Value" for config
 /// uri.
 ///
-/// This function only "updates" the current value, and does not
-/// reload the config.
-void setConfig(const char *uri, const char *jsonPatch);
+/// This function updates the current value and then reload the config.
+bool setConfig(const char *uri, const char *jsonPatch);

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include <fcitx-config/configuration.h>
 #include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/stringutils.h>
@@ -7,6 +8,8 @@
 
 #include "fcitx.h"
 #include "config.h"
+
+using namespace std::literals::string_literals;
 
 static std::string getConfig(const std::string &uri);
 static nlohmann::json &jsonLocate(nlohmann::json &j, const std::string &group,
@@ -33,19 +36,23 @@ std::string getConfig(const std::string &uri) {
                    auto [addonName, subPath] = parseAddonUri(uri);
                    auto *addonInfo = fcitx.addonMgr().addonInfo(addonName);
                    if (!addonInfo) {
-                       return {{"ERROR", "addon does not exist"}};
+                       return {{"ERROR",
+                                "Addon \""s + addonName + "\" does not exist"}};
                    } else if (!addonInfo->isConfigurable()) {
-                       return {{"ERROR", "addon not configurable"}};
+                       return {{"ERROR", "Addon \""s + addonName +
+                                             "\" is not configurable"}};
                    }
                    auto *addon = fcitx.addonMgr().addon(addonName, true);
                    if (!addon) {
-                       return {{"ERROR", "failed to get addon"}};
+                       return {{"ERROR", "Failed to get config for addon \""s +
+                                             addonName + "\""}};
                    }
                    auto *config = subPath.empty()
                                       ? addon->getConfig()
                                       : addon->getSubConfig(subPath);
                    if (!config) {
-                       return {{"ERROR", "failed to get config"}};
+                       return {{"ERROR", "Failed to get config for addon \""s +
+                                             addonName + "\""}};
                    }
                    return configToJson(*config);
                } else if (fcitx::stringutils::startsWith(uri, imConfigPrefix)) {
@@ -53,22 +60,28 @@ std::string getConfig(const std::string &uri) {
                    auto *entry =
                        fcitx.instance()->inputMethodManager().entry(imName);
                    if (!entry) {
-                       return {{"ERROR", "input method doesn't exist"}};
+                       return {{"ERROR", "Input method \""s + imName +
+                                             "\" doesn't exist"}};
                    }
                    if (!entry->isConfigurable()) {
-                       return {{"ERROR", "input method not configurable"}};
+                       return {{"ERROR", "Input method \""s + imName +
+                                             "\" is not configurable"}};
                    }
                    auto *engine = fcitx.instance()->inputMethodEngine(imName);
                    if (!engine) {
-                       return {{"ERROR", "failed to get engine"}};
+                       return {{"ERROR",
+                                "Failed to get engine for input method \""s +
+                                    imName + "\""}};
                    }
                    auto *config = engine->getConfigForInputMethod(*entry);
                    if (!config) {
-                       return {{"ERROR", "failed to get config"}};
+                       return {{"ERROR",
+                                "Failed to get config for input method \""s +
+                                    imName + "\""}};
                    }
                    return configToJson(*config);
                } else {
-                   return {{"ERROR", "bad config uri"}};
+                   return {{"ERROR", "Bad config URI \""s + uri + "\""}};
                }
            })
         .dump();

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -70,7 +70,7 @@ std::string getConfig(const std::string &uri) {
                    return {{"ERROR", "bad config uri"}};
                }
            })
-        .dump(2);
+        .dump();
 }
 
 nlohmann::json &jsonLocate(nlohmann::json &j, const std::string &groupPath,

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -19,6 +19,7 @@ static void mergeSpecAndValue(nlohmann::json &specJson,
                               const nlohmann::json &valueJson);
 static std::tuple<std::string, std::string>
 parseAddonUri(const std::string &uri);
+static size_t counter = 0;
 
 std::string getConfig(const char *uri) { return getConfig(std::string(uri)); }
 
@@ -119,6 +120,7 @@ nlohmann::json configSpecToJson(const fcitx::RawConfig &config) {
             if (!typeField || !descriptionField)
                 continue;
             nlohmann::json &optSpec = jsonLocate(spec, group, option);
+            optSpec["__SortKey"] = counter++;
             optSpec["Type"] = typeField->value();
             optSpec["Description"] = descriptionField->value();
             optSpec["DefaultValue"] =
@@ -158,6 +160,9 @@ nlohmann::json configSpecToJson(const fcitx::Configuration &config) {
 }
 
 nlohmann::json configToJson(const fcitx::Configuration &config) {
+    // Each option or config group is identified with an '__SortKey'
+    // field to preserve insertion order.
+    counter = 0;
     auto specJson = configSpecToJson(config);
     auto valueJson = configValueToJson(config);
     mergeSpecAndValue(specJson, valueJson);

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -67,8 +67,7 @@ std::string getConfig(const std::string &uri) {
                    }
                    return configToJson(*config);
                } else {
-                   FCITX_ASSERT(false);
-                   return {{"ERROR", "unreachable"}};
+                   return {{"ERROR", "bad config uri"}};
                }
            })
         .dump(2);

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -179,6 +179,16 @@ extension Array: FcitxCodable where Element: FcitxCodable {
   // }
 }
 
+extension Optional: FcitxCodable where Wrapped: FcitxCodable {
+  static func decode(json: JSON) throws -> Self {
+    do {
+      return try Wrapped.decode(json: json)
+    } catch {
+      return nil
+    }
+  }
+}
+
 enum FcitxConfigError: Error {
   case fcitxError(String)
   case codingError(FcitxCodingError)

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -26,7 +26,7 @@ public func getConfig(addon: String) throws -> Config {
 }
 
 public func getConfig(im: String) throws -> Config {
-  return try getConfig(uri: "fcitx://config/inputmethod/\(im)/")
+  return try getConfig(uri: "fcitx://config/inputmethod/\(im)")
 }
 
 struct DynamicCodingKey: CodingKey {

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -162,8 +162,9 @@ extension String: FcitxCodable {
 extension Array: FcitxCodable where Element: FcitxCodable {
   static func decode(json: JSON) throws -> Self {
     var result: [Element] = []
-    for (_, subJSON): (String, JSON) in json {
-      result.append(try Element.decode(json: subJSON))
+    // Retrieve by key to preserve order.
+    for i in 0..<json.count {
+      result.append(try Element.decode(json: json[String(i)]))
     }
     return result
   }

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -46,13 +46,15 @@ struct DynamicCodingKey: CodingKey {
 
 func parseJSON(_ json: JSON, _ pathPrefix: String) throws -> Config {
   let description = json["Description"].stringValue
+  let sortKey = json["__SortKey"].intValue
   // Option
   if let type = json["Type"].string,
     !type.contains("$")
   {
     do {
       let option = try parseOptionJSON(json, type)
-      return Config(path: pathPrefix, description: description, kind: .option(option))
+      return Config(
+        path: pathPrefix, description: description, sortKey: sortKey, kind: .option(option))
     } catch {
       throw FcitxCodingError.innerError(path: pathPrefix, context: json, error: error)
     }
@@ -70,9 +72,9 @@ func parseJSON(_ json: JSON, _ pathPrefix: String) throws -> Config {
         path: pathPrefix + "/" + key, context: subJson, error: error)
     }
   }
-  // JSON is unordered -- sort options by description lexically.
-  children.sort { $0.description < $1.description }
-  return Config(path: pathPrefix, description: description, kind: .group(children))
+  children.sort { $0.sortKey < $1.sortKey }
+  return Config(
+    path: pathPrefix, description: description, sortKey: sortKey, kind: .group(children))
 }
 
 func parseOptionJSON(_ json: JSON, _ type: String) throws -> any Option {

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -11,7 +11,6 @@ public func getConfig(uri: String) throws -> Config {
     if json["ERROR"].exists() {
       throw FcitxConfigError.fcitxError(json["ERROR"].stringValue)
     }
-    print("DEBUG: ", jsonString)  // FIXME: Remove
     return try parseJSON(json, "")
   } catch let error as FcitxCodingError {
     throw FcitxConfigError.codingError(error)

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -70,6 +70,8 @@ func parseJSON(_ json: JSON, _ pathPrefix: String) throws -> Config {
         path: pathPrefix + "/" + key, context: subJson, error: error)
     }
   }
+  // JSON is unordered -- sort options by description lexically.
+  children.sort { $0.description < $1.description }
   return Config(path: pathPrefix, description: description, kind: .group(children))
 }
 

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -93,6 +93,8 @@ func parseOptionJSON(_ json: JSON, _ type: String) throws -> any Option {
   } else if type == "List|Key" {
     // TODO
     return try ListOption<String>.decode(json: json)
+  } else if type == "External" {
+    return try ExternalOption.decode(json: json)
   } else {
     return try UnknownOption.decode(json: json)
   }

--- a/src/config/globalconfig.swift
+++ b/src/config/globalconfig.swift
@@ -1,7 +1,7 @@
 import Logging
 import SwiftUI
 
-class GlobalConfig: NSWindowController {
+class GlobalConfigController: NSWindowController {
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),

--- a/src/config/globalconfig.swift
+++ b/src/config/globalconfig.swift
@@ -31,7 +31,7 @@ struct GlobalConfigView: View {
         Spacer()
         Button("Print") {
           // Should see changes.
-          print(model)
+          print(model.encodeValue())
         }
       }
     }.padding()

--- a/src/config/globalconfig.swift
+++ b/src/config/globalconfig.swift
@@ -1,3 +1,4 @@
+import Fcitx
 import Logging
 import SwiftUI
 
@@ -32,6 +33,9 @@ struct GlobalConfigView: View {
         Button("Print") {
           // Should see changes.
           print(model.encodeValue())
+        }
+        Button("Save") {
+          Fcitx.setConfig("fcitx://config/global", model.encodeValue())
         }
       }
     }.padding()

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -271,8 +271,12 @@ struct AvailableInputMethodView: View {
     NavigationSplitView {
       List(selection: $viewModel.selectedLanguageCode) {
         let languages = Array(viewModel.availableIMs.keys).sorted()
+        let en = Locale(identifier: "en_US")
+        let locale = Locale()
         ForEach(languages, id: \.self) { language in
-          Text(language)
+          Text(
+            locale.localizedString(forIdentifier: language) ?? en.localizedString(
+              forIdentifier: language) ?? language)
         }
       }
     } detail: {

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -1,0 +1,138 @@
+import Fcitx
+import Logging
+import SwiftUI
+
+class InputMethodConfigController: NSWindowController {
+  convenience init() {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+      styleMask: [.titled, .closable],
+      backing: .buffered, defer: false)
+    window.title = "Global Config"
+    window.center()
+    self.init(window: window)
+    window.contentView = NSHostingView(rootView: InputMethodConfigView())
+  }
+}
+
+private struct Group: Identifiable, Codable {
+  var name: String
+  var inputMethods: [InputMethod]
+  let id = UUID()
+
+  private enum CodingKeys: CodingKey {
+    case name
+    case inputMethods
+  }
+}
+
+private struct InputMethod: Identifiable, Codable {
+  var name: String
+  var displayName: String
+  let id = UUID()
+
+  private enum CodingKeys: CodingKey {
+    case name
+    case displayName
+  }
+}
+
+@Observable
+private class ViewModel {
+  var groups = [Group]()
+  var selectedInputMethod: String? {
+    didSet {
+      updateModel()
+    }
+  }
+  var configModel: Config?
+  var errorMsg: String?
+
+  init() {
+    refresh()
+  }
+
+  func refresh() {
+    do {
+      let jsonStr = String(all_input_methods())
+      if let jsonData = jsonStr.data(using: .utf8) {
+        groups = try JSONDecoder().decode([Group].self, from: jsonData)
+      } else {
+        FCITX_ERROR("Couldn't decode input method config")
+      }
+    } catch {
+      FCITX_ERROR("Couldn't load input method config: \(error)")
+    }
+  }
+
+  func updateModel() {
+    guard let im = selectedInputMethod else { return }
+    do {
+      configModel = try getConfig(im: im)
+      errorMsg = nil
+    } catch {
+      configModel = nil
+      errorMsg = error.localizedDescription
+    }
+  }
+
+  func save() {
+    // TODO
+  }
+}
+
+struct InputMethodConfigView: View {
+  @State private var viewModel = ViewModel()
+
+  var body: some View {
+    NavigationSplitView {
+      VStack {
+        List(selection: $viewModel.selectedInputMethod) {
+          ForEach($viewModel.groups, id: \.name) { $group in
+            let header = Text(group.name)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .contentShape(Rectangle())
+              .contextMenu {
+                Button("Rename group") {}
+                Button("Add input method") {}
+                Button("Remove group") {}
+              }
+            Section(header: header) {
+              ForEach($group.inputMethods, id: \.name) { $inputMethod in
+                Text(inputMethod.displayName)
+                  .contextMenu {
+                    Button("Remove input method") {}
+                  }
+              }
+              .onMove { indices, newOffset in
+                viewModel.groups.move(fromOffsets: indices, toOffset: newOffset)
+              }
+            }
+          }
+          .onMove { indices, newOffset in
+            viewModel.groups.move(fromOffsets: indices, toOffset: newOffset)
+          }
+        }
+        .contextMenu {
+          Button("Add group") {}
+        }
+      }
+    } detail: {
+      if let selectedInputMethod = viewModel.selectedInputMethod {
+        if let configModel = viewModel.configModel {
+          ScrollView {
+            buildView(config: configModel)
+          }
+        } else if let errorMsg = viewModel.errorMsg {
+          Text("Cannot show config for \(selectedInputMethod): \(errorMsg)")
+        }
+      } else {
+        Text("Select an input method from the side bar.")
+      }
+    }
+  }
+}
+
+#Preview {
+  InputMethodConfigView()
+}

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -106,6 +106,10 @@ private class ViewModel: ObservableObject {
       FCITX_ERROR("Couldn't save input method groups: \(error)")
     }
   }
+
+  func removeGroup(_ name: String) {
+    groups.removeAll(where: { $0.name == name })
+  }
 }
 
 struct InputMethodConfigView: View {

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -133,7 +133,14 @@ struct InputMethodConfigView: View {
       if let selectedItem = viewModel.selectedItem {
         if let configModel = viewModel.configModel {
           ScrollView([.vertical, .horizontal]) {
-            buildView(config: configModel)
+            VStack {
+              buildView(config: configModel)
+              Button("Save") {
+                if let name = viewModel.selectedIMName {
+                  setConfig("fcitx://config/inputmethod/\(name)", configModel.encodeValue())
+                }
+              }
+            }
           }
           .defaultScrollAnchor(.topTrailing)
         } else if let errorMsg = viewModel.errorMsg {
@@ -151,8 +158,12 @@ struct InputMethodConfigView: View {
       didSet {
         configModel = nil
         updateModel()
+        if let uuid = selectedItem {
+          selectedIMName = uuidToIM[uuid]
+        }
       }
     }
+    @Published var selectedIMName: String?
     @Published var configModel: Config?
     @Published var errorMsg: String?
     var uuidToIM = [UUID: String]()

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -85,6 +85,7 @@ struct InputMethodConfigView: View {
                   Button("Add") {
                     viewModel.addItems(&group, inputMethodsToAdd)
                     addingInputMethod = false
+                    inputMethodsToAdd = Set()
                   }
                   Button("Cancel") {
                     addingInputMethod = false

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -8,7 +8,7 @@ class InputMethodConfigController: NSWindowController {
       contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
       styleMask: [.titled, .closable],
       backing: .buffered, defer: false)
-    window.title = "Global Config"
+    window.title = "Input Methods"
     window.center()
     self.init(window: window)
     window.contentView = NSHostingView(rootView: InputMethodConfigView())

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -49,10 +49,10 @@ private class ViewModel {
   var errorMsg: String?
 
   init() {
-    refresh()
+    load()
   }
 
-  func refresh() {
+  func load() {
     do {
       let jsonStr = String(all_input_methods())
       if let jsonData = jsonStr.data(using: .utf8) {
@@ -73,6 +73,7 @@ private class ViewModel {
     } catch {
       configModel = nil
       errorMsg = error.localizedDescription
+      FCITX_ERROR("Couldn't build config view: \(error)")
     }
   }
 

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -311,13 +311,8 @@ struct AvailableInputMethodView: View {
   var body: some View {
     NavigationSplitView {
       List(selection: $viewModel.selectedLanguageCode) {
-        let languages = Array(viewModel.availableIMs.keys).sorted()
-        let en = Locale(identifier: "en_US")
-        let locale = Locale()
-        ForEach(languages, id: \.self) { language in
-          Text(
-            locale.localizedString(forIdentifier: language) ?? en.localizedString(
-              forIdentifier: language) ?? language)
+        ForEach(viewModel.languages(), id: \.code) { language in
+          Text(language.localized)
         }
       }
     } detail: {
@@ -389,6 +384,39 @@ struct AvailableInputMethodView: View {
       } else {
         errorMsg = "Cannot decode json string into UTF-8 data"
       }
+    }
+
+    fileprivate struct LocalizedLanguageCode: Comparable {
+      let code: String
+      let localized: String
+
+      init(code: String) {
+        self.code = code
+        if code == "" {
+          localized = "Unknown"
+        } else {
+          let locale = Locale.current
+          let s = locale.localizedString(forIdentifier: code) ?? ""
+          localized = s != "" ? s : "Unknown - \(code)"
+        }
+      }
+
+      public static func < (lhs: Self, rhs: Self) -> Bool {
+        let curIdent = Locale.current.identifier.prefix(2)
+        if lhs.code.prefix(2) == curIdent {
+          return true
+        } else if rhs.code.prefix(2) == curIdent {
+          return false
+        } else {
+          return lhs.localized.localizedCompare(rhs.localized) == .orderedAscending
+        }
+      }
+    }
+
+    fileprivate func languages() -> [LocalizedLanguageCode] {
+      return Array(availableIMs.keys)
+        .map { LocalizedLanguageCode(code: $0) }
+        .sorted()
     }
   }
 }

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -238,6 +238,7 @@ struct InputMethodConfigView: View {
       for im in ims {
         let item = GroupItem(name: im.uniqueName, displayName: im.displayName)
         group.inputMethods.append(item)
+        uuidToIM[item.id] = item.name
       }
     }
   }

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -132,7 +132,7 @@ struct InputMethodConfigView: View {
     } detail: {
       if let selectedItem = viewModel.selectedItem {
         if let configModel = viewModel.configModel {
-          ScrollView([.vertical, .horizontal]) {
+          let scrollView = ScrollView([.vertical, .horizontal]) {
             VStack {
               buildView(config: configModel)
               Button("Save") {
@@ -142,7 +142,11 @@ struct InputMethodConfigView: View {
               }
             }
           }
-          .defaultScrollAnchor(.topTrailing)
+          if #available(macOS 14.0, *) {
+            scrollView.defaultScrollAnchor(.topTrailing)
+          } else {
+            scrollView
+          }
         } else if let errorMsg = viewModel.errorMsg {
           Text("Cannot show config for \(selectedItem): \(errorMsg)")
         }

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -61,7 +61,7 @@ private class ViewModel: ObservableObject {
     uuidToIM.removeAll(keepingCapacity: true)
     loading = true
     do {
-      let jsonStr = String(all_input_methods())
+      let jsonStr = String(Fcitx.imGetGroups())
       if let jsonData = jsonStr.data(using: .utf8) {
         groups = try JSONDecoder().decode([Group].self, from: jsonData)
         for group in groups {
@@ -98,7 +98,7 @@ private class ViewModel: ObservableObject {
     do {
       let data = try JSONEncoder().encode(groups)
       if let jsonStr = String(data: data, encoding: .utf8) {
-        Fcitx.set_input_method_groups(jsonStr)
+        Fcitx.imSetGroups(jsonStr)
       } else {
         FCITX_ERROR("Couldn't save input method groups: failed to encode data as UTF-8")
       }

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -6,12 +6,16 @@ class InputMethodConfigController: NSWindowController {
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
-      styleMask: [.titled, .closable, .resizable, .utilityWindow],
+      styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
       backing: .buffered, defer: false)
     window.title = "Input Methods"
     window.center()
     self.init(window: window)
     window.contentView = NSHostingView(rootView: InputMethodConfigView())
+    window.level = .floating
+    window.titlebarAppearsTransparent = true
+    window.toolbar?.showsBaselineSeparator = false
+    window.toolbarStyle = .unified
   }
 }
 

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -121,9 +121,10 @@ struct InputMethodConfigView: View {
     } detail: {
       if let selectedInputMethod = viewModel.selectedInputMethod {
         if let configModel = viewModel.configModel {
-          ScrollView {
+          ScrollView([.vertical, .horizontal]) {
             buildView(config: configModel)
           }
+          .defaultScrollAnchor(.topTrailing)
         } else if let errorMsg = viewModel.errorMsg {
           Text("Cannot show config for \(selectedInputMethod): \(errorMsg)")
         }

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -17,16 +17,26 @@ class InputMethodConfigController: NSWindowController {
 
 private struct Group: Identifiable, Codable {
   var name: String
-  var inputMethods: [InputMethod]
+  var inputMethods: [GroupItem]
   let id = UUID()
 
   private enum CodingKeys: CodingKey {
-    case name
-    case inputMethods
+    case name, inputMethods
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    name = try container.decode(String.self, forKey: .name)
+    inputMethods = (try? container.decode([GroupItem].self, forKey: .inputMethods)) ?? []
+  }
+
+  init(name: String, inputMethods: [GroupItem]) {
+    self.name = name
+    self.inputMethods = inputMethods
   }
 }
 
-private struct InputMethod: Identifiable, Codable {
+private struct GroupItem: Identifiable, Codable {
   var name: String
   var displayName: String
   let id = UUID()
@@ -43,7 +53,7 @@ private class ViewModel: ObservableObject {
       save()
     }
   }
-  @Published var selectedInputMethod: UUID? {
+  @Published var selectedItem: UUID? {
     didSet {
       updateModel()
     }
@@ -70,16 +80,18 @@ private class ViewModel: ObservableObject {
           }
         }
       } else {
-        FCITX_ERROR("Couldn't decode input method config")
+        errorMsg = "Couldn't decode input method config: not UTF-8"
+        FCITX_ERROR("Couldn't decode input method config: not UTF-8")
       }
     } catch {
+      errorMsg = "Couldn't load input method config: \(error)"
       FCITX_ERROR("Couldn't load input method config: \(error)")
     }
     loading = false
   }
 
   func updateModel() {
-    guard let uuid = selectedInputMethod else { return }
+    guard let uuid = selectedItem else { return }
     guard let im = uuidToIM[uuid] else { return }
     do {
       configModel = try getConfig(im: im)
@@ -115,63 +127,58 @@ private class ViewModel: ObservableObject {
   }
 
   func removeGroup(_ name: String) {
+    if groups.count <= 1 {
+      return
+    }
     groups.removeAll(where: { $0.name == name })
   }
 
-  @Published var inputDialogInput: String = ""
-  @Published var hasInputDialog = false
-  func showInputDialog() {
-    inputDialogInput = ""
-    hasInputDialog = true
+  func renameGroup(_ group: inout Group, _ name: String) {
+    if name == "" {
+      return
+    }
+    group.name = name
   }
-  func cancelInputDialog() {
-    inputDialogInput = ""
-    hasInputDialog = false
+
+  func removeItem(_ group: inout Group, _ uuid: UUID) {
+    group.inputMethods.removeAll(where: { $0.id == uuid })
   }
 }
 
 struct InputMethodConfigView: View {
   @StateObject private var viewModel = ViewModel()
-
-  @State var showConfirmDialog = false
+  @StateObject var addGroupDialog = InputDialog(title: "Add an empty group", prompt: "Group name")
+  @StateObject var renameGroupDialog = InputDialog(title: "Rename group", prompt: "Group name")
 
   var body: some View {
     NavigationSplitView {
-      List(selection: $viewModel.selectedInputMethod) {
+      List(selection: $viewModel.selectedItem) {
         ForEach($viewModel.groups) { $group in
           let header = Text(group.name)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
             .contextMenu {
-              Button("Rename group") {}
-              Button("Add input method") {}
+              Button("Rename group") {
+                renameGroupDialog.show { input in
+                  viewModel.renameGroup(&group, input)
+                }
+              }
+              }
               Button("Remove group") {
-                showConfirmDialog = true
+                viewModel.removeGroup(group.name)
               }
             }
-            .alert(
-              "Confirm deletion",
-              isPresented: $showConfirmDialog,
-              presenting: ()
-            ) { details in
-              Button(role: .destructive) {
-                viewModel.removeGroup(group.name)
-                showConfirmDialog = false
-              } label: {
-                Text("Delete")
-              }
-              Button(role: .cancel) {
-              } label: {
-                Text("Cancel")
-              }
-            } message: {
-              Text("Are you sure you want to delete the \"\(group.name)\" group?")
+            .sheet(isPresented: $renameGroupDialog.presented) {
+              renameGroupDialog.view()
+            }
             }
           Section(header: header) {
             ForEach($group.inputMethods) { $inputMethod in
               Text(inputMethod.displayName)
                 .contextMenu {
-                  Button("Remove input method") {}
+                  Button("Remove input method") {
+                    viewModel.removeItem(&group, inputMethod.id)
+                  }
                 }
             }
             .onMove { indices, newOffset in
@@ -185,37 +192,89 @@ struct InputMethodConfigView: View {
       }
       .contextMenu {
         Button("Add group") {
-          viewModel.showInputDialog()
+          addGroupDialog.show { input in
+            viewModel.addGroup(input)
+          }
         }
       }
-      .sheet(isPresented: $viewModel.hasInputDialog) {
-        VStack {
-          TextField("Group name", text: $viewModel.inputDialogInput)
-          HStack {
-            Button("OK") {
-              viewModel.addGroup(viewModel.inputDialogInput)
-              viewModel.cancelInputDialog()
-            }
-            Button("Cancel") {
-              viewModel.cancelInputDialog()
-            }
-          }
-        }.padding()
+      .sheet(isPresented: $addGroupDialog.presented) {
+        addGroupDialog.view()
       }
     } detail: {
-      if let selectedInputMethod = viewModel.selectedInputMethod {
+      if let selectedItem = viewModel.selectedItem {
         if let configModel = viewModel.configModel {
           ScrollView([.vertical, .horizontal]) {
             buildView(config: configModel)
           }
           .defaultScrollAnchor(.topTrailing)
         } else if let errorMsg = viewModel.errorMsg {
-          Text("Cannot show config for \(selectedInputMethod): \(errorMsg)")
+          Text("Cannot show config for \(selectedItem): \(errorMsg)")
         }
       } else {
         Text("Select an input method from the side bar.")
       }
     }
+  }
+}
+
+/// A common modal dialog view-model + view builder for getting user
+/// input.
+///
+/// The basic pattern is:
+/// 1. define a StateObject for the dialog:
+/// ```
+/// @StateObject private var myDialog = InputDialog(title: "Title", prompt: "Some string")
+/// ```
+/// 2. Add the dialog view as a sheet to view:
+/// ```
+/// view.sheet(isPresented: $myDialog.presented) { myDialog.view() }
+/// ```
+/// 3. When you want to ask for user input, use `myDialog.show` and
+/// pass in a callback to handle the user input:
+/// ```
+/// Button("Click me") {
+///   myDialog.show() { userInput in
+///     print("You input: \(userInput)")
+///   }
+/// }
+/// ```
+class InputDialog: ObservableObject {
+  @Published var presented = false
+  @Published var userInput = ""
+  let title: String
+  let prompt: String
+  var continuation: ((String) -> Void)?
+
+  init(title: String, prompt: String) {
+    self.title = title
+    self.prompt = prompt
+  }
+
+  func show(_ continuation: @escaping (String) -> Void) {
+    self.continuation = continuation
+    presented = true
+  }
+
+  @ViewBuilder
+  func view() -> some View {
+    let myBinding = Binding(
+      get: { self.userInput },
+      set: { self.userInput = $0 }
+    )
+    VStack {
+      TextField(title, text: myBinding)
+      HStack {
+        Button("OK") {
+          if let cont = self.continuation {
+            cont(self.userInput)
+          }
+          self.presented = false
+        }
+        Button("Cancel") {
+          self.presented = false
+        }
+      }
+    }.padding()
   }
 }
 

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -6,7 +6,7 @@ class InputMethodConfigController: NSWindowController {
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
-      styleMask: [.titled, .closable],
+      styleMask: [.titled, .closable, .resizable, .utilityWindow],
       backing: .buffered, defer: false)
     window.title = "Input Methods"
     window.center()

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -132,21 +132,21 @@ struct InputMethodConfigView: View {
     } detail: {
       if let selectedItem = viewModel.selectedItem {
         if let configModel = viewModel.configModel {
-          let scrollView = ScrollView([.vertical, .horizontal]) {
-            VStack {
+          VStack {
+            let scrollView = ScrollView([.vertical, .horizontal]) {
               buildView(config: configModel)
-              Button("Save") {
-                if let name = viewModel.selectedIMName {
-                  setConfig("fcitx://config/inputmethod/\(name)", configModel.encodeValue())
-                }
+            }
+            if #available(macOS 14.0, *) {
+              scrollView.defaultScrollAnchor(.topTrailing)
+            } else {
+              scrollView
+            }
+            Button("Save") {
+              if let name = viewModel.selectedIMName {
+                setConfig("fcitx://config/inputmethod/\(name)", configModel.encodeValue())
               }
             }
-          }
-          if #available(macOS 14.0, *) {
-            scrollView.defaultScrollAnchor(.topTrailing)
-          } else {
-            scrollView
-          }
+          }.padding()
         } else if let errorMsg = viewModel.errorMsg {
           Text("Cannot show config for \(selectedItem): \(errorMsg)")
         }

--- a/src/config/menu.swift
+++ b/src/config/menu.swift
@@ -8,8 +8,11 @@ extension FcitxInputController {
   static var pluginManager: PluginManager = {
     return PluginManager()
   }()
-  static var globalConfig: GlobalConfig = {
-    return GlobalConfig()
+  static var globalConfigController: GlobalConfigController = {
+    return GlobalConfigController()
+  }()
+  static var inputMethodConfigController: InputMethodConfigController = {
+    return InputMethodConfigController()
   }()
 
   @objc func plugin(_: Any? = nil) {
@@ -26,6 +29,10 @@ extension FcitxInputController {
   }
 
   @objc func globalConfig(_: Any? = nil) {
-    FcitxInputController.globalConfig.showWindow(nil)
+    FcitxInputController.globalConfigController.showWindow(nil)
+  }
+
+  @objc func inputMethod(_: Any? = nil) {
+    FcitxInputController.inputMethodConfigController.showWindow(nil)
   }
 }

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -28,15 +28,15 @@ class SimpleOption<T: FcitxCodable>: Option, ObservableObject, FcitxCodable {
   let defaultValue: T
   @Published var value: T
 
-  required init(defaultValue: T, value: T) {
+  required init(defaultValue: T, value: T?) {
     self.defaultValue = defaultValue
-    self.value = value
+    self.value = value ?? defaultValue
   }
 
   static func decode(json: JSON) throws -> Self {
     return Self(
       defaultValue: try T.decode(json: json["DefaultValue"]),
-      value: try T.decode(json: json["Value"])
+      value: try T?.decode(json: json["Value"])
     )
   }
 }
@@ -52,13 +52,13 @@ typealias StringOption = SimpleOption<String>
 
 class IntegerOption: Option, ObservableObject, FcitxCodable {
   let defaultValue: Int
-  let max: Int
-  let min: Int
+  let max: Int?
+  let min: Int?
   @Published var value: Int
 
-  required init(defaultValue: Int, value: Int, min: Int, max: Int) {
+  required init(defaultValue: Int, value: Int?, min: Int?, max: Int?) {
     self.defaultValue = defaultValue
-    self.value = value
+    self.value = value ?? defaultValue
     self.min = min
     self.max = max
   }
@@ -66,9 +66,9 @@ class IntegerOption: Option, ObservableObject, FcitxCodable {
   static func decode(json: JSON) throws -> Self {
     return Self(
       defaultValue: try Int.decode(json: json["DefaultValue"]),
-      value: try Int.decode(json: json["Value"]),
-      min: try Int.decode(json: json["IntMin"]),
-      max: try Int.decode(json: json["IntMax"])
+      value: try Int?.decode(json: json["Value"]),
+      min: try Int?.decode(json: json["IntMin"]),
+      max: try Int?.decode(json: json["IntMax"])
     )
   }
 }
@@ -80,10 +80,10 @@ class EnumOption: Option, ObservableObject, FcitxCodable {
   @Published var value: String
 
   required init(
-    defaultValue: String, value: String, enumStrings: [String], enumStringsI18n: [String]
+    defaultValue: String, value: String?, enumStrings: [String], enumStringsI18n: [String]
   ) {
     self.defaultValue = defaultValue
-    self.value = value
+    self.value = value ?? defaultValue
     self.enumStrings = enumStrings
     self.enumStringsI18n = enumStringsI18n
   }
@@ -93,7 +93,7 @@ class EnumOption: Option, ObservableObject, FcitxCodable {
     let enumsi18n = try [String].decode(json: json["EnumI18n"])
     return Self(
       defaultValue: json["DefaultValue"].stringValue,
-      value: json["Value"].stringValue,
+      value: json["Value"].string,
       enumStrings: enums,
       enumStringsI18n: enumsi18n.count < enums.count ? enums : enumsi18n
     )
@@ -111,16 +111,16 @@ class ListOption<T: FcitxCodable>: Option, ObservableObject, FcitxCodable {
   @Published var value: [T]
   let elementType: String
 
-  required init(defaultValue: [T], value: [T], elementType: String) {
+  required init(defaultValue: [T], value: [T]?, elementType: String) {
     self.defaultValue = defaultValue
+    self.value = value ?? defaultValue
     self.elementType = elementType
-    self.value = value
   }
 
   static func decode(json: JSON) throws -> Self {
     return Self(
       defaultValue: try [T].decode(json: json["DefaultValue"]),
-      value: try [T].decode(json: json["Value"]),
+      value: try [T]?.decode(json: json["Value"]),
       elementType: json["Type"].stringValue
     )
   }

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -7,6 +7,7 @@ import SwiftyJSON
 public struct Config: Identifiable {
   public let path: String
   public let description: String
+  public let sortKey: Int
   public let kind: ConfigKind
   public let id = UUID()
 }

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -88,11 +88,13 @@ class EnumOption: Option, ObservableObject, FcitxCodable {
   }
 
   static func decode(json: JSON) throws -> Self {
+    let enums = try [String].decode(json: json["Enum"])
+    let enumsi18n = try [String].decode(json: json["EnumI18n"])
     return Self(
       defaultValue: json["DefaultValue"].stringValue,
       value: json["Value"].stringValue,
-      enumStrings: try [String].decode(json: json["Enum"]),
-      enumStringsI18n: try [String].decode(json: json["EnumI18n"])
+      enumStrings: enums,
+      enumStringsI18n: enumsi18n.count < enums.count ? enums : enumsi18n
     )
   }
 }

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -15,26 +15,13 @@ struct Config: Identifiable {
 
 extension Config: FcitxCodable {
   static func decode(json: JSON) throws -> Config {
-    return try parseJSON(json, "")
+    return try jsonToConfig(json, "")
   }
 
   /// Encode the config as a "value json" J.
   /// Such that J["A"]["B"]["C"] is the value for option A/B/C.
   func encodeValueJSON() -> JSON {
-    switch self.kind {
-    case .group(let children):
-      var json = JSON()
-      for c in children {
-        if let key = c.key() {
-          json[key] = c.encodeValueJSON()
-        } else {
-          FCITX_ERROR("Cannot encode option at path " + c.path)
-        }
-      }
-      return json
-    case .option(let opt):
-      return opt.encodeValueJSON()
-    }
+    return configToJson(self)
   }
 }
 

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -134,12 +134,10 @@ extension ListOption: CustomStringConvertible {
 
 struct ExternalOption: Option, FcitxCodable {
   let value: () = ()
-  let launchSubConfig: Bool
   let external: String
 
   static func decode(json: JSON) throws -> Self {
     ExternalOption(
-      launchSubConfig: try Bool.decode(json: json["LaunchSubConfig"]),
       external: try String.decode(json: json["External"])
     )
   }

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -12,6 +12,19 @@ public struct Config: Identifiable {
   public let id = UUID()
 }
 
+extension Config {
+  func resetToDefault() {
+    switch self.kind {
+    case .group(let children):
+      for child in children {
+        child.resetToDefault()
+      }
+    case .option(let opt):
+      opt.resetToDefault()
+    }
+  }
+}
+
 public enum ConfigKind {
   case group([Config])
   case option(any Option)
@@ -22,6 +35,7 @@ public enum ConfigKind {
 public protocol Option {
   associatedtype Storage
   var value: Storage { get }
+  func resetToDefault()
 }
 
 class SimpleOption<T: FcitxCodable>: Option, ObservableObject, FcitxCodable {
@@ -38,6 +52,10 @@ class SimpleOption<T: FcitxCodable>: Option, ObservableObject, FcitxCodable {
       defaultValue: try T.decode(json: json["DefaultValue"]),
       value: try T?.decode(json: json["Value"])
     )
+  }
+
+  func resetToDefault() {
+    value = defaultValue
   }
 }
 
@@ -71,6 +89,10 @@ class IntegerOption: Option, ObservableObject, FcitxCodable {
       max: try Int?.decode(json: json["IntMax"])
     )
   }
+
+  func resetToDefault() {
+    value = defaultValue
+  }
 }
 
 class EnumOption: Option, ObservableObject, FcitxCodable {
@@ -98,6 +120,10 @@ class EnumOption: Option, ObservableObject, FcitxCodable {
       enumStringsI18n: enumsi18n.count < enums.count ? enums : enumsi18n
     )
   }
+
+  func resetToDefault() {
+    value = defaultValue
+  }
 }
 
 extension EnumOption: CustomStringConvertible {
@@ -124,6 +150,10 @@ class ListOption<T: FcitxCodable>: Option, ObservableObject, FcitxCodable {
       elementType: json["Type"].stringValue
     )
   }
+
+  func resetToDefault() {
+    value = defaultValue
+  }
 }
 
 extension ListOption: CustomStringConvertible {
@@ -141,6 +171,8 @@ struct ExternalOption: Option, FcitxCodable {
       external: try String.decode(json: json["External"])
     )
   }
+
+  func resetToDefault() {}
 }
 
 struct UnknownOption: Option, FcitxCodable {
@@ -154,6 +186,8 @@ struct UnknownOption: Option, FcitxCodable {
       raw: json
     )
   }
+
+  func resetToDefault() {}
 }
 
 // TODO KeyOption

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -140,7 +140,7 @@ let testConfig = Config(
       kind: .option(StringOption(defaultValue: "", value: "semicolon"))),
     Config(
       path: "external", description: "External test", sortKey: 3,
-      kind: .option(ExternalOption(launchSubConfig: true, external: "fcitx://addon/punctuation"))),
+      kind: .option(ExternalOption(external: "fcitx://addon/punctuation"))),
     Config(
       path: "Shuangpin Profile", description: "双拼方案", sortKey: 4,
       kind: .option(

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -84,11 +84,9 @@ struct ListOptionView: View {
   let label: String
   @ObservedObject var model: ListOption<String>
   var body: some View {
-    Section(label) {
-      List {
-        ForEach(0..<model.value.count, id: \.self) { index in
-          Text(model.value[index])
-        }
+    LabeledContent(label) {
+      ForEach(0..<model.value.count, id: \.self) { index in
+        Text(model.value[index])
       }
     }
   }

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -35,10 +35,14 @@ struct IntegerOptionView: View {
       TextField(label, value: $model.value, formatter: numberFormatter)
         .textFieldStyle(RoundedBorderTextFieldStyle())
         .onChange(of: model.value) { newValue in
-          if newValue > model.max {
-            model.value = model.max
-          } else if newValue < model.min {
-            model.value = model.min
+          if let max = model.max,
+            newValue > max
+          {
+            model.value = max
+          } else if let min = model.min,
+            newValue < min
+          {
+            model.value = min
           }
         }
         .padding(.trailing, 60)

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -214,7 +214,7 @@ let testConfig = Config(
   VStack {
     buildView(config: testConfig)
     Button("Print") {
-      print(testConfig)
+      print(testConfig.encodeValue())
     }
   }
 }

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -130,27 +130,28 @@ func buildView(config: Config) -> AnyView {
 let testConfig = Config(
   path: "Fuzzy",
   description: "Fuzzy",
+  sortKey: 0,
   kind: .group([
     Config(
-      path: "AN_ANG", description: "Fuzzy an ang",
+      path: "AN_ANG", description: "Fuzzy an ang", sortKey: 1,
       kind: .option(BooleanOption(defaultValue: false, value: true))),
     Config(
-      path: "foo", description: "FOOOO!",
+      path: "foo", description: "FOOOO!", sortKey: 2,
       kind: .option(StringOption(defaultValue: "", value: "semicolon"))),
     Config(
-      path: "external", description: "External test",
+      path: "external", description: "External test", sortKey: 3,
       kind: .option(ExternalOption(launchSubConfig: true, external: "fcitx://addon/punctuation"))),
     Config(
-      path: "Shuangpin Profile", description: "双拼方案",
+      path: "Shuangpin Profile", description: "双拼方案", sortKey: 4,
       kind: .option(
         EnumOption(
           defaultValue: "Ziranma", value: "MS", enumStrings: ["Ziranma", "MS"],
           enumStringsI18n: ["自然码", "微软"]))),
     Config(
-      path: "interval", description: "int test",
+      path: "interval", description: "int test", sortKey: 5,
       kind: .option(IntegerOption(defaultValue: 0, value: 10, min: 0, max: 1000))),
     Config(
-      path: "list", description: "List test",
+      path: "list", description: "List test", sortKey: 6,
       kind: .option(
         ListOption(defaultValue: ["a", "b", "c"], value: ["c", "d"], elementType: "String"))
     ),

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -82,8 +82,8 @@ class FcitxInputController: IMKInputController {
     let menu = NSMenu()
 
     // Group switcher
-    let groupNames = JSON(parseJSON: String(input_method_groups())).arrayValue
-    let currentGroup = String(get_current_input_method_group())
+    let groupNames = JSON(parseJSON: String(Fcitx.imGetGroupNames())).arrayValue
+    let currentGroup = String(Fcitx.imGetCurrentGroupName())
     if groupNames.count > 1 {
       for groupName in groupNames {
         let groupName = groupName.stringValue
@@ -98,9 +98,9 @@ class FcitxInputController: IMKInputController {
     }
 
     // Input method switcher
-    let inputMethods = JSON(parseJSON: String(current_input_method_list()))
-    let currentIM = String(get_current_input_method())
-    for (_, inputMethod) in inputMethods {
+    let curGroup = JSON(parseJSON: String(Fcitx.imGetCurrentGroup()))
+    let currentIM = String(Fcitx.imGetCurrentIMName())
+    for (_, inputMethod) in curGroup {
       let imName = inputMethod["name"].stringValue
       let nativeName = inputMethod["displayName"].stringValue
       let item = NSMenuItem(
@@ -117,7 +117,7 @@ class FcitxInputController: IMKInputController {
     menu.addItem(NSMenuItem.separator())
 
     // Additional actions for the current IC
-    let actionJson = String(current_actions())
+    let actionJson = String(Fcitx.getActions())
     if let data = actionJson.data(using: .utf8) {
       do {
         let actions = try JSONDecoder().decode(Array<FcitxAction>.self, from: data)
@@ -142,19 +142,19 @@ class FcitxInputController: IMKInputController {
 
   @objc func switchGroup(sender: Any?) {
     if let groupName = repObjectIMK(sender) as? String {
-      set_current_input_method_group(groupName)
+      Fcitx.imSetCurrentGroup(groupName)
     }
   }
 
   @objc func switchInputMethod(sender: Any?) {
     if let imName = repObjectIMK(sender) as? String {
-      set_current_input_method(imName)
+      Fcitx.imSetCurrentIM(imName)
     }
   }
 
   @objc func activateFcitxAction(sender: Any?) {
     if let action = repObjectIMK(sender) as? FcitxAction {
-      activate_action_by_id(Int32(action.id))
+      Fcitx.activateActionById(Int32(action.id))
     }
   }
 }

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -132,6 +132,7 @@ class FcitxInputController: IMKInputController {
       }
     }
 
+    menu.addItem(withTitle: "Input Methods", action: #selector(inputMethod(_:)), keyEquivalent: "")
     menu.addItem(withTitle: "Global Config", action: #selector(globalConfig(_:)), keyEquivalent: "")
     menu.addItem(withTitle: "Plugin Manager", action: #selector(plugin(_:)), keyEquivalent: "")
     menu.addItem(withTitle: "Restart", action: #selector(restart(_:)), keyEquivalent: "")

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -2,6 +2,7 @@ import CxxFrontend
 import Fcitx
 import InputMethodKit
 import Logging
+import SwiftyJSON
 
 class FcitxInputController: IMKInputController {
   var uuid: ICUUID
@@ -81,11 +82,11 @@ class FcitxInputController: IMKInputController {
     let menu = NSMenu()
 
     // Group switcher
-    let groupNames = String(input_method_groups()).split(separator: "\n")
+    let groupNames = JSON(parseJSON: String(input_method_groups())).arrayValue
     let currentGroup = String(get_current_input_method_group())
     if groupNames.count > 1 {
       for groupName in groupNames {
-        let groupName = String(groupName)
+        let groupName = groupName.stringValue
         let item = NSMenuItem(title: groupName, action: #selector(switchGroup), keyEquivalent: "")
         item.representedObject = groupName
         if groupName == currentGroup {
@@ -97,12 +98,11 @@ class FcitxInputController: IMKInputController {
     }
 
     // Input method switcher
-    let inputMethodPairs = String(input_method_list()).split(separator: "\n")
+    let inputMethods = JSON(parseJSON: String(current_input_method_list()))
     let currentIM = String(get_current_input_method())
-    for inputMethodPair in inputMethodPairs {
-      let parts = inputMethodPair.split(separator: ":", maxSplits: 1)
-      let imName = String(parts[0])
-      let nativeName = String(parts[1])
+    for (_, inputMethod) in inputMethods {
+      let imName = inputMethod["name"].stringValue
+      let nativeName = inputMethod["displayName"].stringValue
       let item = NSMenuItem(
         title: nativeName,
         action: #selector(switchInputMethod),

--- a/src/fcitx-public.h
+++ b/src/fcitx-public.h
@@ -14,8 +14,15 @@ void restart_fcitx_thread() noexcept;
 
 // NOTE: It's impossible to use std::vector<std::string> directly
 // until Swift fixes C++ interop.
+// Returns a json array of strings.
 std::string input_method_groups() noexcept;
-std::string input_method_list() noexcept;
+// Retruns json [["id1", "name1"], ["id2", "name2"], ...].
+std::string current_input_method_list() noexcept;
+// Returns json
+// [{"name": "group name", "inputMethods":
+//   [{"name": ..., "displayName": ...}...]}...].
+std::string all_input_methods() noexcept;
+std::string input_method_list(const char *) noexcept;
 void set_current_input_method_group(const char *) noexcept;
 std::string get_current_input_method_group() noexcept;
 void set_current_input_method(const char *) noexcept;

--- a/src/fcitx-public.h
+++ b/src/fcitx-public.h
@@ -31,6 +31,11 @@ void imSetGroups(const char *json) noexcept;
 std::string imGetCurrentIMName() noexcept;
 void imSetCurrentIM(const char *imName) noexcept;
 
+// Returns a json array of Input Methods.
+// type InputMethod := {uniqueName:str, name:str, nativeName:str,
+// languageCode:str, icon:str, label:str, isConfigurable: bool}
+std::string imGetAvailableIMs() noexcept;
+
 std::string getActions() noexcept;
 void activateActionById(int id) noexcept;
 

--- a/src/fcitx-public.h
+++ b/src/fcitx-public.h
@@ -22,6 +22,8 @@ std::string current_input_method_list() noexcept;
 // [{"name": "group name", "inputMethods":
 //   [{"name": ..., "displayName": ...}...]}...].
 std::string all_input_methods() noexcept;
+// uses the same format as all_input_methods
+void set_input_method_groups(const char *) noexcept;
 std::string input_method_list(const char *) noexcept;
 void set_current_input_method_group(const char *) noexcept;
 std::string get_current_input_method_group() noexcept;

--- a/src/fcitx-public.h
+++ b/src/fcitx-public.h
@@ -14,22 +14,24 @@ void restart_fcitx_thread() noexcept;
 
 // NOTE: It's impossible to use std::vector<std::string> directly
 // until Swift fixes C++ interop.
-// Returns a json array of strings.
-std::string input_method_groups() noexcept;
-// Retruns json [["id1", "name1"], ["id2", "name2"], ...].
-std::string current_input_method_list() noexcept;
+// Returns a json array of group names.
+std::string imGetGroupNames() noexcept;
+std::string imGetCurrentGroupName() noexcept;
+void imSetCurrentGroup(const char *groupName) noexcept;
+
+// Returns a json array of { "name": ..., "displayName": ... }
+std::string imGetCurrentGroup() noexcept;
+
 // Returns json
 // [{"name": "group name", "inputMethods":
 //   [{"name": ..., "displayName": ...}...]}...].
-std::string all_input_methods() noexcept;
-// uses the same format as all_input_methods
-void set_input_method_groups(const char *) noexcept;
-std::string input_method_list(const char *) noexcept;
-void set_current_input_method_group(const char *) noexcept;
-std::string get_current_input_method_group() noexcept;
-void set_current_input_method(const char *) noexcept;
-std::string get_current_input_method() noexcept;
-std::string current_actions() noexcept;
-void activate_action_by_id(int id) noexcept;
+std::string imGetGroups() noexcept;
+void imSetGroups(const char *json) noexcept;
+
+std::string imGetCurrentIMName() noexcept;
+void imSetCurrentIM(const char *imName) noexcept;
+
+std::string getActions() noexcept;
+void activateActionById(int id) noexcept;
 
 #endif

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -177,7 +177,7 @@ void restart_fcitx_thread() noexcept {
     start_fcitx_thread();
 }
 
-std::string input_method_groups() noexcept {
+std::string imGetGroupNames() noexcept {
     return with_fcitx([](Fcitx &fcitx) {
         nlohmann::json j;
         auto groups = fcitx.instance()->inputMethodManager().groups();
@@ -185,6 +185,18 @@ std::string input_method_groups() noexcept {
             j.push_back(g);
         }
         return j.dump();
+    });
+}
+
+std::string imGetCurrentGroupName() noexcept {
+    return with_fcitx([=](Fcitx &fcitx) {
+        return fcitx.instance()->inputMethodManager().currentGroup().name();
+    });
+}
+
+void imSetCurrentGroup(const char *groupName) noexcept {
+    return with_fcitx([=](Fcitx &fcitx) {
+        fcitx.instance()->inputMethodManager().setCurrentGroup(groupName);
     });
 }
 
@@ -197,7 +209,7 @@ static nlohmann::json json_describe_im(const fcitx::InputMethodEntry *entry) {
     return j;
 }
 
-std::string current_input_method_list() noexcept {
+std::string imGetCurrentGroup() noexcept {
     return with_fcitx([](Fcitx &fcitx) noexcept {
         nlohmann::json j;
         auto &imMgr = fcitx.instance()->inputMethodManager();
@@ -212,7 +224,7 @@ std::string current_input_method_list() noexcept {
     });
 }
 
-std::string all_input_methods() noexcept {
+std::string imGetGroups() noexcept {
     return with_fcitx([](Fcitx &fcitx) {
         auto &imMgr = fcitx.instance()->inputMethodManager();
         auto groups = imMgr.groups();
@@ -232,7 +244,7 @@ std::string all_input_methods() noexcept {
     });
 }
 
-void set_input_method_groups(const char *json) noexcept {
+void imSetGroups(const char *json) noexcept {
     auto j = nlohmann::json::parse(json);
     with_fcitx([j = std::move(j)](Fcitx &fcitx) {
         auto &imMgr = fcitx.instance()->inputMethodManager();
@@ -252,24 +264,12 @@ void set_input_method_groups(const char *json) noexcept {
     });
 }
 
-void set_current_input_method_group(const char *groupName) noexcept {
-    return with_fcitx([=](Fcitx &fcitx) {
-        fcitx.instance()->inputMethodManager().setCurrentGroup(groupName);
-    });
-}
-
-std::string get_current_input_method_group() noexcept {
-    return with_fcitx([=](Fcitx &fcitx) {
-        return fcitx.instance()->inputMethodManager().currentGroup().name();
-    });
-}
-
-void set_current_input_method(const char *imName) noexcept {
+void imSetCurrentIM(const char *imName) noexcept {
     return with_fcitx(
         [=](Fcitx &fcitx) { fcitx.instance()->setCurrentInputMethod(imName); });
 }
 
-std::string get_current_input_method() noexcept {
+std::string imGetCurrentIMName() noexcept {
     return with_fcitx(
         [=](Fcitx &fcitx) { return fcitx.instance()->currentInputMethod(); });
 }
@@ -300,7 +300,7 @@ static nlohmann::json actionToJson(fcitx::Action *action,
 ///
 /// Each array element has a structure like:
 /// type Item = { name: str, desc: str, checked?: bool, children: Array<Item>? }
-std::string current_actions() noexcept {
+std::string getActions() noexcept {
     return with_fcitx([](Fcitx &fcitx) {
         nlohmann::json j = nlohmann::json::array();
         if (auto *ic = fcitx.instance()->mostRecentInputContext()) {
@@ -317,7 +317,7 @@ std::string current_actions() noexcept {
     });
 }
 
-void activate_action_by_id(int id) noexcept {
+void activateActionById(int id) noexcept {
     with_fcitx([=](Fcitx &fcitx) {
         auto *action =
             fcitx.instance()->userInterfaceManager().lookupActionById(id);

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -260,6 +260,11 @@ void imSetGroups(const char *json) noexcept {
             }
             imMgr.setGroup(updated);
         }
+        for (const auto &groupName : imMgr.groups()) {
+            if (j.find(groupName) == j.end()) {
+                imMgr.removeGroup(groupName);
+            }
+        }
         imMgr.save();
     });
 }

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -232,6 +232,26 @@ std::string all_input_methods() noexcept {
     });
 }
 
+void set_input_method_groups(const char *json) noexcept {
+    auto j = nlohmann::json::parse(json);
+    with_fcitx([j = std::move(j)](Fcitx &fcitx) {
+        auto &imMgr = fcitx.instance()->inputMethodManager();
+        for (const auto &g : j) {
+            if (!imMgr.group(g["name"])) {
+                imMgr.addEmptyGroup(g["name"]);
+            }
+            auto updated = *imMgr.group(g["name"]);
+            auto &imList = updated.inputMethodList();
+            imList.clear();
+            for (const auto &im : g["inputMethods"]) {
+                imList.emplace_back(im["name"]);
+            }
+            imMgr.setGroup(updated);
+        }
+        imMgr.save();
+    });
+}
+
 void set_current_input_method_group(const char *groupName) noexcept {
     return with_fcitx([=](Fcitx &fcitx) {
         fcitx.instance()->inputMethodManager().setCurrentGroup(groupName);

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -46,6 +46,11 @@ Fcitx::Fcitx() {
     setupEnv();
 }
 
+Fcitx::~Fcitx() {
+    exit();
+    teardown();
+}
+
 void Fcitx::setup() {
     setupInstance();
     frontend_ =
@@ -105,8 +110,11 @@ void Fcitx::exec() {
 }
 
 void Fcitx::exit() {
-    dispatcher_->detach();
-    instance_->exit();
+    // the fcitx instance may have been destroyed by stop_fcitx_thread.
+    if (dispatcher_)
+        dispatcher_->detach();
+    if (instance_)
+        instance_->exit();
 }
 
 void Fcitx::schedule(std::function<void()> func) {

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -251,6 +251,7 @@ void imSetGroups(const char *json) noexcept {
         for (const auto &g : j) {
             if (!imMgr.group(g["name"])) {
                 imMgr.addEmptyGroup(g["name"]);
+                continue;
             }
             auto updated = *imMgr.group(g["name"]);
             auto &imList = updated.inputMethodList();

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -279,6 +279,25 @@ std::string imGetCurrentIMName() noexcept {
         [=](Fcitx &fcitx) { return fcitx.instance()->currentInputMethod(); });
 }
 
+std::string imGetAvailableIMs() noexcept {
+    return with_fcitx([](Fcitx &fcitx) {
+        nlohmann::json j;
+        fcitx.instance()->inputMethodManager().foreachEntries(
+            [&j](const fcitx::InputMethodEntry &entry) {
+                j.push_back(
+                    nlohmann::json{{"name", entry.name()},
+                                   {"uniqueName", entry.uniqueName()},
+                                   {"nativeName", entry.nativeName()},
+                                   {"isConfigurable", entry.isConfigurable()},
+                                   {"languageCode", entry.languageCode()},
+                                   {"icon", entry.icon()},
+                                   {"label", entry.label()}});
+                return true;
+            });
+        return j.dump();
+    });
+}
+
 static nlohmann::json actionToJson(fcitx::Action *action,
                                    fcitx::InputContext *ic) {
     nlohmann::json j;

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -248,10 +248,11 @@ void imSetGroups(const char *json) noexcept {
     auto j = nlohmann::json::parse(json);
     with_fcitx([j = std::move(j)](Fcitx &fcitx) {
         auto &imMgr = fcitx.instance()->inputMethodManager();
+        std::unordered_set<std::string> liveGroups;
         for (const auto &g : j) {
+            liveGroups.insert(g["name"]);
             if (!imMgr.group(g["name"])) {
                 imMgr.addEmptyGroup(g["name"]);
-                continue;
             }
             auto updated = *imMgr.group(g["name"]);
             auto &imList = updated.inputMethodList();
@@ -262,7 +263,7 @@ void imSetGroups(const char *json) noexcept {
             imMgr.setGroup(updated);
         }
         for (const auto &groupName : imMgr.groups()) {
-            if (j.find(groupName) == j.end()) {
+            if (!liveGroups.count(groupName)) {
                 imMgr.removeGroup(groupName);
             }
         }

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -228,7 +228,7 @@ std::string all_input_methods() noexcept {
                 j.push_back(g);
             }
         }
-        return j;
+        return j.dump();
     });
 }
 

--- a/src/fcitx.h
+++ b/src/fcitx.h
@@ -12,7 +12,7 @@
 class Fcitx final {
 public:
     Fcitx();
-    ~Fcitx() = default;
+    ~Fcitx();
     Fcitx(Fcitx &) = delete;
 
     static Fcitx &shared();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,3 +22,7 @@ add_executable(config-swift testconfig.swift
 target_include_directories(config-swift PRIVATE "${PROJECT_SOURCE_DIR}/deps/SwiftyJSON/Source/SwiftyJSON")
 target_link_libraries(config-swift f5mtest ${SWIFT_LIBS})
 add_test(NAME config-swift COMMAND config-swift)
+
+add_executable(config-cpp testconfig.cpp)
+target_link_libraries(config-cpp f5mtest ${SWIFT_LIBS})
+add_test(NAME config-cpp COMMAND config-cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_library(f5mtest STATIC
+    "${PROJECT_SOURCE_DIR}/src/fcitx.cpp"
+    "${PROJECT_SOURCE_DIR}/src/config/config.cpp"
+)
+target_include_directories(f5mtest PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${PROJECT_SOURCE_DIR}/fcitx5/src/im/keyboard"
+    "${PROJECT_SOURCE_DIR}/fcitx5/src/modules/quickphrase/"
+    "${PROJECT_BINARY_DIR}/fcitx5"
+)
+target_link_libraries(f5mtest PUBLIC
+    "-Xlinker -rpath -Xlinker '${CMAKE_INSTALL_PREFIX}/lib'"
+    Fcitx5::Core keyboard macosnotifications macosfrontend WebviewCandidateWindow
+)
+set(SWIFT_LIBS SwiftyJSON Logging SwiftNotify SwiftFrontend)
+
+# Config and Option
+add_executable(config-swift testconfig.swift
+    ${PROJECT_SOURCE_DIR}/src/config/optionmodels.swift
+    ${PROJECT_SOURCE_DIR}/src/config/config.swift
+)
+target_include_directories(config-swift PRIVATE "${PROJECT_SOURCE_DIR}/deps/SwiftyJSON/Source/SwiftyJSON")
+target_link_libraries(config-swift f5mtest ${SWIFT_LIBS})
+add_test(NAME config-swift COMMAND config-swift)

--- a/tests/testconfig.cpp
+++ b/tests/testconfig.cpp
@@ -8,7 +8,7 @@ int main() {
     sleep(1);
     
     // Can get information about input methods.
-    all_input_methods();
+    imGetGroups();
     
     // Can get config.
     {

--- a/tests/testconfig.cpp
+++ b/tests/testconfig.cpp
@@ -1,0 +1,28 @@
+#include "fcitx-public.h"
+#include "config/config-public.h"
+#include <nlohmann/json.hpp>
+#include <unistd.h>
+
+int main() {
+    start_fcitx_thread();
+    sleep(1);
+    
+    // Can get information about input methods.
+    all_input_methods();
+    
+    // Can get config.
+    {
+        nlohmann::json j = getConfig("fcitx//config/global");
+        assert(j.find("ERROR") == j.end());
+    }
+    {
+        nlohmann::json j = getConfig("fcitx//addons/punctuation");
+        assert(j.find("ERROR") == j.end());
+    }
+    {
+        nlohmann::json j = getConfig("fcitx//addons/inputmethod/pinyin");
+        assert(j.find("ERROR") == j.end());
+    }
+    
+    stop_fcitx_thread();
+}

--- a/tests/testconfig.cpp
+++ b/tests/testconfig.cpp
@@ -13,20 +13,40 @@ int main() {
 
     // Can get config.
     {
-        nlohmann::json j = getConfig("fcitx//config/global");
-        assert(j.find("ERROR") == j.end());
+        auto j = nlohmann::json::parse(getConfig("fcitx://config/global"));
+        assert(j.is_object() && j.find("ERROR") == j.end());
     }
     {
-        nlohmann::json j = getConfig("fcitx//addons/punctuation");
-        assert(j.find("ERROR") == j.end());
+        auto j = nlohmann::json::parse(
+            getConfig("fcitx://config/addon/punctuation"));
+        assert(j.is_object() && j.find("ERROR") == j.end());
     }
     {
-        nlohmann::json j = getConfig("fcitx//addons/inputmethod/pinyin");
-        assert(j.find("ERROR") == j.end());
+        auto j = nlohmann::json::parse(
+            getConfig("fcitx://config/inputmethod/pinyin"));
+        assert(j.is_object() && j.find("ERROR") == j.end());
     }
 
     // Can get available input methods.
     { std::cerr << imGetAvailableIMs() << std::endl; }
+
+    // Can set config
+    {
+        nlohmann::json j{{"Behavior", {{"ActiveByDefault", "False"}}}};
+        assert(setConfig("fcitx://config/global", j.dump().c_str()));
+        auto updated =
+            nlohmann::json::parse(getConfig("fcitx://config/global"));
+        assert(updated["Behavior"]["ActiveByDefault"]["Value"]
+                   .get<std::string>() == "False");
+    }
+    {
+        nlohmann::json j{{"Behavior", {{"ActiveByDefault", "True"}}}};
+        assert(setConfig("fcitx://config/global", j.dump().c_str()));
+        auto updated =
+            nlohmann::json::parse(getConfig("fcitx://config/global"));
+        assert(updated["Behavior"]["ActiveByDefault"]["Value"]
+                   .get<std::string>() == "True");
+    }
 
     stop_fcitx_thread();
 }

--- a/tests/testconfig.cpp
+++ b/tests/testconfig.cpp
@@ -1,15 +1,16 @@
+#include <unistd.h>
+#include <iostream>
+#include <nlohmann/json.hpp>
 #include "fcitx-public.h"
 #include "config/config-public.h"
-#include <nlohmann/json.hpp>
-#include <unistd.h>
 
 int main() {
     start_fcitx_thread();
     sleep(1);
-    
+
     // Can get information about input methods.
     imGetGroups();
-    
+
     // Can get config.
     {
         nlohmann::json j = getConfig("fcitx//config/global");
@@ -23,6 +24,9 @@ int main() {
         nlohmann::json j = getConfig("fcitx//addons/inputmethod/pinyin");
         assert(j.find("ERROR") == j.end());
     }
-    
+
+    // Can get available input methods.
+    { std::cerr << imGetAvailableIMs() << std::endl; }
+
     stop_fcitx_thread();
 }

--- a/tests/testconfig.cpp
+++ b/tests/testconfig.cpp
@@ -31,21 +31,14 @@ int main() {
     { std::cerr << imGetAvailableIMs() << std::endl; }
 
     // Can set config
-    {
-        nlohmann::json j{{"Behavior", {{"ActiveByDefault", "False"}}}};
+    std::vector<std::string> values{"False", "True"};
+    for (const auto &value : values) {
+        nlohmann::json j{{"Behavior", {{"ActiveByDefault", value}}}};
         assert(setConfig("fcitx://config/global", j.dump().c_str()));
         auto updated =
             nlohmann::json::parse(getConfig("fcitx://config/global"));
         assert(updated["Behavior"]["ActiveByDefault"]["Value"]
-                   .get<std::string>() == "False");
-    }
-    {
-        nlohmann::json j{{"Behavior", {{"ActiveByDefault", "True"}}}};
-        assert(setConfig("fcitx://config/global", j.dump().c_str()));
-        auto updated =
-            nlohmann::json::parse(getConfig("fcitx://config/global"));
-        assert(updated["Behavior"]["ActiveByDefault"]["Value"]
-                   .get<std::string>() == "True");
+                   .get<std::string>() == value);
     }
 
     stop_fcitx_thread();

--- a/tests/testconfig.swift
+++ b/tests/testconfig.swift
@@ -1,0 +1,122 @@
+@testable import Fcitx
+import SwiftyJSON
+
+@_cdecl("main")
+func main() {
+  start_fcitx_thread()
+  try! testGetConfigFromFcitx()
+  try! testDecode()
+  stop_fcitx_thread()
+}
+
+func testGetConfigFromFcitx() throws {
+  let _ = try getConfig(uri: "fcitx://config/global")
+
+  do {
+    let _ = try getConfig(uri: "fcitx://NOT-FOUND");
+  } catch is FcitxConfigError {
+    assert(true)
+  } catch {
+    assert(false)
+  }
+}
+
+func testDecode() throws {
+  // empty object
+  try {
+    let json = JSON(parseJSON: #"null"#)
+    let cfg = try parseJSON(json, "")
+    switch cfg.kind {
+    case .group(_): assert(true)
+    case .option(_): assert(false)
+    }
+  }();
+
+  // path
+  try {
+    let json = JSON(parseJSON: #"{"A": {"Description": "inside a" , "B": {"Description": "inside b", "C": {"Description": "inside c"}}}}"#)
+    let root = try parseJSON(json, "root")
+    switch root.kind{
+    case .option: assert(false)
+    case .group(let rootchildren):
+      assert(rootchildren.count == 1)
+      let a = rootchildren[0]
+      assert(a.description == "inside a")
+      assert(a.path == "root/A")
+      switch a.kind {
+      case .option(_): assert(false)
+      case .group(let achildren):
+        assert(achildren.count == 1)
+        let b = achildren[0]
+        assert(b.description == "inside b")
+        assert(b.path == "root/A/B")
+        switch b.kind {
+        case .option(_): assert(false)
+        case .group(let bchildren):
+          assert(bchildren.count == 1)
+          let c = bchildren[0]
+          assert(c.description == "inside c")
+          assert(c.path == "root/A/B/C")
+        }
+      }
+    }
+  }()
+
+  // Boolean
+  try {
+    let json = JSON(parseJSON: #"{"Type": "Boolean", "Value": "True", "DefaultValue": "False", "Description": "bool"}"#)
+    let cfg = try parseJSON(json, "")
+    assert(cfg.description == "bool")
+    switch cfg.kind {
+    case .option(let opt as BooleanOption):
+      assert(opt.defaultValue == false)
+      assert(opt.value == true)
+    case .group(_): assert(false)
+    case .option(_): assert(false)
+    }
+  }();
+
+  // Integer
+  try {
+    let json = JSON(parseJSON: #"{"Type": "Integer", "Value": "100", "DefaultValue": "0", "IntMin": "0", "IntMax": "1000", "Description": "int"}"#)
+    let cfg = try parseJSON(json, "")
+    assert(cfg.description == "int")
+    switch cfg.kind {
+    case .option(let opt as IntegerOption):
+      assert(opt.defaultValue == 0)
+      assert(opt.value == 100)
+      assert(opt.min == 0)
+      assert(opt.max == 1000)
+    case .group(_): assert(false)
+    case .option(_): assert(false)
+    }
+  }();
+
+  // String
+  try {
+    let json = JSON(parseJSON: #"{"Type": "String", "Value": "Hello Fcitx", "DefaultValue": "HSN", "Description": "str"}"#)
+    let cfg = try parseJSON(json, "")
+    assert(cfg.description == "str")
+    switch cfg.kind {
+    case .option(let opt as StringOption):
+      assert(opt.defaultValue == "HSN")
+      assert(opt.value == "Hello Fcitx")
+    case .group(_): assert(false)
+    case .option(_): assert(false)
+    }
+  }();
+
+  // Enum
+  try {
+    let json = JSON(parseJSON: #"{"Type": "Enum", "Value": "No", "DefaultValue": "Yes", "Enum": {"0": "Yes", "1": "No"},  "EnumI18n": {"0": "是", "1": "否"}, "Description": "enum"}"#)
+    let cfg = try parseJSON(json, "")
+    assert(cfg.description == "enum")
+    switch cfg.kind {
+    case .option(let opt as EnumOption):
+      assert(opt.defaultValue == "Yes")
+      assert(opt.value == "No")
+    case .group(_): assert(false)
+    case .option(_): assert(false)
+    }
+  }();
+}

--- a/tests/testconfig.swift
+++ b/tests/testconfig.swift
@@ -1,12 +1,15 @@
 @testable import Fcitx
 import SwiftyJSON
+import Foundation
 
 @_cdecl("main")
-func main() {
+func main() -> Int {
   start_fcitx_thread()
+  Thread.sleep(forTimeInterval: 1)
   try! testGetConfigFromFcitx()
   try! testDecode()
   stop_fcitx_thread()
+  return 0
 }
 
 func testGetConfigFromFcitx() throws {

--- a/tests/testconfig.swift
+++ b/tests/testconfig.swift
@@ -1,6 +1,7 @@
-@testable import Fcitx
-import SwiftyJSON
 import Foundation
+import SwiftyJSON
+
+@testable import Fcitx
 
 @_cdecl("main")
 func main() -> Int {
@@ -8,6 +9,7 @@ func main() -> Int {
   Thread.sleep(forTimeInterval: 1)
   try! testGetConfigFromFcitx()
   try! testDecode()
+  testEncode()
   stop_fcitx_thread()
   return 0
 }
@@ -16,7 +18,7 @@ func testGetConfigFromFcitx() throws {
   let _ = try getConfig(uri: "fcitx://config/global")
 
   do {
-    let _ = try getConfig(uri: "fcitx://NOT-FOUND");
+    let _ = try getConfig(uri: "fcitx://NOT-FOUND")
   } catch is FcitxConfigError {
     assert(true)
   } catch {
@@ -33,13 +35,16 @@ func testDecode() throws {
     case .group(_): assert(true)
     case .option(_): assert(false)
     }
-  }();
+  }()
 
   // path
   try {
-    let json = JSON(parseJSON: #"{"A": {"Description": "inside a" , "B": {"Description": "inside b", "C": {"Description": "inside c"}}}}"#)
+    let json = JSON(
+      parseJSON:
+        #"{"A": {"Description": "inside a" , "B": {"Description": "inside b", "C": {"Description": "inside c"}}}}"#
+    )
     let root = try parseJSON(json, "root")
-    switch root.kind{
+    switch root.kind {
     case .option: assert(false)
     case .group(let rootchildren):
       assert(rootchildren.count == 1)
@@ -67,7 +72,9 @@ func testDecode() throws {
 
   // Boolean
   try {
-    let json = JSON(parseJSON: #"{"Type": "Boolean", "Value": "True", "DefaultValue": "False", "Description": "bool"}"#)
+    let json = JSON(
+      parseJSON:
+        #"{"Type": "Boolean", "Value": "True", "DefaultValue": "False", "Description": "bool"}"#)
     let cfg = try parseJSON(json, "")
     assert(cfg.description == "bool")
     switch cfg.kind {
@@ -77,11 +84,14 @@ func testDecode() throws {
     case .group(_): assert(false)
     case .option(_): assert(false)
     }
-  }();
+  }()
 
   // Integer
   try {
-    let json = JSON(parseJSON: #"{"Type": "Integer", "Value": "100", "DefaultValue": "0", "IntMin": "0", "IntMax": "1000", "Description": "int"}"#)
+    let json = JSON(
+      parseJSON:
+        #"{"Type": "Integer", "Value": "100", "DefaultValue": "0", "IntMin": "0", "IntMax": "1000", "Description": "int"}"#
+    )
     let cfg = try parseJSON(json, "")
     assert(cfg.description == "int")
     switch cfg.kind {
@@ -93,11 +103,13 @@ func testDecode() throws {
     case .group(_): assert(false)
     case .option(_): assert(false)
     }
-  }();
+  }()
 
   // String
   try {
-    let json = JSON(parseJSON: #"{"Type": "String", "Value": "Hello Fcitx", "DefaultValue": "HSN", "Description": "str"}"#)
+    let json = JSON(
+      parseJSON:
+        #"{"Type": "String", "Value": "Hello Fcitx", "DefaultValue": "HSN", "Description": "str"}"#)
     let cfg = try parseJSON(json, "")
     assert(cfg.description == "str")
     switch cfg.kind {
@@ -107,11 +119,14 @@ func testDecode() throws {
     case .group(_): assert(false)
     case .option(_): assert(false)
     }
-  }();
+  }()
 
   // Enum
   try {
-    let json = JSON(parseJSON: #"{"Type": "Enum", "Value": "No", "DefaultValue": "Yes", "Enum": {"0": "Yes", "1": "No"},  "EnumI18n": {"0": "是", "1": "否"}, "Description": "enum"}"#)
+    let json = JSON(
+      parseJSON:
+        #"{"Type": "Enum", "Value": "No", "DefaultValue": "Yes", "Enum": {"0": "Yes", "1": "No"},  "EnumI18n": {"0": "是", "1": "否"}, "Description": "enum"}"#
+    )
     let cfg = try parseJSON(json, "")
     assert(cfg.description == "enum")
     switch cfg.kind {
@@ -121,5 +136,18 @@ func testDecode() throws {
     case .group(_): assert(false)
     case .option(_): assert(false)
     }
-  }();
+  }()
+}
+
+func testEncode() {
+  assert((try! String.decode("abc")) == "abc")
+  assert("abc".encodeValue() == "abc")
+
+  assert(try! Int.decode("\"100\"") == 100)
+  assert(100.encodeValue() == "\"100\"")
+
+  assert(true.encodeValue() == "\"True\"")
+
+  assert(try! Bool.decode("\"False\"") == false)
+  assert(false.encodeValue() == "\"False\"")
 }


### PR DESCRIPTION
This PR primarily adds the input method config tool:

Input methods (and groups) can now be:
1. queried, listed: by default
2. added: to add an IM, right click on the name of a group and select "Add input method"; to add a group, right click on the unused area and select "Add group".
3. removed: to remove an IM, right click on the IM and select "Remove input method"; to remove a group, right click on the name of a group and select "Remove group".
4. reordered: just drag and drop
the config can be loaded, changed, and saved.

A screen recording demonstrating adding and changing shuangpin settings:

https://github.com/fcitx-contrib/fcitx5-macos/assets/23358293/49acd704-8882-4cc3-975c-f81a5a803eec


Other assorted changes:

- Added `tests`. It currently relies on locally installed plugins, so CI is delayed until it is in better shape.
- Implemented `External` for opening subconfig. External commands like `xdg-open foo` are not supported.
- A bunch of smaller fixes for robustness and a few known UI problems.
