### PR TITLE
Simulate key release

### DIFF
--- a/macosfrontend/macosfrontend.conf.in.in
+++ b/macosfrontend/macosfrontend.conf.in.in
@@ -4,3 +4,4 @@ Type=StaticLibrary
 Library=libmacosfrontend
 Category=Frontend
 Version=@PROJECT_VERSION@
+Configurable=True

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -150,7 +150,7 @@ MacosFrontend::MacosFrontend(Instance *instance)
 void MacosFrontend::updateConfig() {
     simulateKeyRelease_ = config_.simulateKeyRelease.value();
     simulateKeyReleaseDelay_ =
-        static_cast<long>(config_.simulateKeyRelease.value()) * 1000L;
+        static_cast<long>(config_.simulateKeyReleaseDelay.value()) * 1000L;
 }
 
 void MacosFrontend::reloadConfig() {

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -234,14 +234,11 @@ bool MacosFrontend::keyEvent(ICUUID uuid, const Key &key, bool isRelease) {
                     KeyEvent releaseEvent(ic, key, true);
                     ic->keyEvent(releaseEvent);
                 }
-                source->setEnabled(false);
                 delete source;
                 return true;
             });
         // Leak it from unique_ptr, and let it delete itself when it's done.
         auto timeEventPtr = timeEvent.release();
-        timeEventPtr->setEnabled(true);
-        timeEventPtr->setOneShot();
     }
 
     return keyEvent.accepted();

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -11,6 +11,7 @@
 #include "macosfrontend-swift.h"
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <fcitx-utils/event.h>
 #include <fcitx/addonmanager.h>
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputpanel.h>
@@ -125,6 +126,7 @@ private:
 MacosFrontend::MacosFrontend(Instance *instance)
     : instance_(instance), activeIC_(nullptr),
       window_(std::make_unique<candidate_window::WebviewCandidateWindow>()) {
+    reloadConfig();
     eventHandlers_.emplace_back(instance_->watchEvent(
         EventType::InputContextFlushUI, EventWatcherPhase::Default,
         [this](Event &event) {
@@ -143,6 +145,23 @@ MacosFrontend::MacosFrontend(Instance *instance)
         }));
     window_->set_select_callback(
         [this](size_t index) { selectCandidate(index); });
+}
+
+void MacosFrontend::updateConfig() {
+    simulateKeyRelease_ = config_.simulateKeyRelease.value();
+    simulateKeyReleaseDelay_ =
+        static_cast<long>(config_.simulateKeyRelease.value()) * 1000L;
+}
+
+void MacosFrontend::reloadConfig() {
+    readAsIni(config_, ConfPath);
+    updateConfig();
+}
+
+void MacosFrontend::save() {
+    config_.simulateKeyRelease.setValue(simulateKeyRelease_);
+    config_.simulateKeyReleaseDelay.setValue(simulateKeyReleaseDelay_ / 1000);
+    safeSaveAsIni(config_, ConfPath);
 }
 
 void MacosFrontend::updateInputPanel(const fcitx::Text &preedit,
@@ -205,6 +224,26 @@ bool MacosFrontend::keyEvent(ICUUID uuid, const Key &key, bool isRelease) {
     }
     KeyEvent keyEvent(ic, key, isRelease);
     ic->keyEvent(keyEvent);
+
+    if (simulateKeyRelease_ && !isRelease && !key.isModifier()) {
+        auto timeEvent = instance()->eventLoop().addTimeEvent(
+            CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + simulateKeyReleaseDelay_,
+            10000, [this, ic, key = key](EventSourceTime *source, uint64_t) {
+                FCITX_DEBUG() << "Simulate key release " << key.toString();
+                if (activeIC_ == ic) {
+                    KeyEvent releaseEvent(ic, key, true);
+                    ic->keyEvent(releaseEvent);
+                }
+                source->setEnabled(false);
+                delete source;
+                return true;
+            });
+        // Leak it from unique_ptr, and let it delete itself when it's done.
+        auto timeEventPtr = timeEvent.release();
+        timeEventPtr->setEnabled(true);
+        timeEventPtr->setOneShot();
+    }
+
     return keyEvent.accepted();
 }
 
@@ -253,6 +292,7 @@ bool process_key(ICUUID uuid, uint32_t unicode, uint32_t osxModifiers,
         osx_modifiers_to_fcitx_keystates(osxModifiers),
         osx_keycode_to_fcitx_keycode(osxKeycode),
     };
+
     return with_fcitx([=](Fcitx &fcitx) {
         auto that = dynamic_cast<fcitx::MacosFrontend *>(fcitx.frontend());
         return that->keyEvent(uuid, parsedKey, isRelease);

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -26,12 +26,12 @@ enum class PanelShowFlag : int;
 using PanelShowFlags = fcitx::Flags<PanelShowFlag>;
 
 FCITX_CONFIGURATION(MacosFrontendConfig,
-                    fcitx::Option<bool> simulateKeyRelease{
-                        this, "SimulateKeyRelease", _("Simulate key release")};
-                    fcitx::Option<int> simulateKeyReleaseDelay{
+                    Option<bool> simulateKeyRelease{this, "SimulateKeyRelease",
+                                                    _("Simulate key release")};
+                    Option<int, IntConstrain> simulateKeyReleaseDelay{
                         this, "SimulateKeyReleaseDelay",
                         _("Delay of simulated key release in milliseconds"),
-                        100};);
+                        100, IntConstrain(10, 1500)};);
 
 class MacosFrontend : public AddonInstance {
 public:

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -8,6 +8,9 @@
 #ifndef _FCITX5_MACOS_MACOSFRONTEND_H_
 #define _FCITX5_MACOS_MACOSFRONTEND_H_
 
+#include <fcitx-config/configuration.h>
+#include <fcitx-config/iniparser.h>
+#include <fcitx-utils/i18n.h>
 #include <fcitx/addonfactory.h>
 #include <fcitx/addoninstance.h>
 #include <fcitx/addonmanager.h>
@@ -22,11 +25,24 @@ class MacosInputContext;
 enum class PanelShowFlag : int;
 using PanelShowFlags = fcitx::Flags<PanelShowFlag>;
 
+FCITX_CONFIGURATION(MacosFrontendConfig,
+                    fcitx::Option<bool> simulateKeyRelease{
+                        this, "SimulateKeyRelease", _("Simulate key release")};
+                    fcitx::Option<int> simulateKeyReleaseDelay{
+                        this, "SimulateKeyReleaseDelay",
+                        _("Delay of simulated key release in milliseconds"),
+                        100};);
+
 class MacosFrontend : public AddonInstance {
 public:
     MacosFrontend(Instance *instance);
 
     Instance *instance() { return instance_; }
+
+    void updateConfig();
+    void reloadConfig() override;
+    void save() override;
+    const Configuration *getConfig() const override { return &config_; }
 
     void updateCandidateList(const std::vector<std::string> &candidates,
                              const std::vector<std::string> &labels, int size,
@@ -44,6 +60,12 @@ public:
 private:
     Instance *instance_;
     std::unique_ptr<candidate_window::CandidateWindow> window_;
+
+    MacosFrontendConfig config_;
+    bool simulateKeyRelease_;
+    long simulateKeyReleaseDelay_;
+
+    static const inline std::string ConfPath = "conf/macosfrontend.conf";
 
     MacosInputContext *activeIC_;
     std::vector<std::unique_ptr<HandlerTableEntry<EventHandler>>>


### PR DESCRIPTION
Support chord typing in rime.

This is by default disabled. To enable, modify `~/.config/fcitx5/conf/macosfrontend.conf`:

```
# False by default
SimulateKeyRelease=True
# in milliseconds, 100ms by default
SimulateKeyReleaseDelay=100
```