### PR TITLE
Dynamic switching of activation policies

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -16,8 +16,8 @@
   <string>org.fcitx.inputmethod.Fcitx5_Connection</string>
   <key>InputMethodServerControllerClass</key>
   <string>Fcitx5.FcitxInputController</string>
-  <key>LSUIElement</key>
-  <string>1</string>
+  <key>LSBackgroundOnly</key>
+  <true/>
   <key>tsInputMethodCharacterRepertoireKey</key>
   <array>
     <string>Latn</string>

--- a/src/config/globalconfig.swift
+++ b/src/config/globalconfig.swift
@@ -2,7 +2,7 @@ import Fcitx
 import Logging
 import SwiftUI
 
-class GlobalConfigController: NSWindowController {
+class GlobalConfigController: ConfigWindowController {
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -2,7 +2,7 @@ import Fcitx
 import Logging
 import SwiftUI
 
-class InputMethodConfigController: NSWindowController {
+class InputMethodConfigController: ConfigWindowController {
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),

--- a/src/config/menu.swift
+++ b/src/config/menu.swift
@@ -36,3 +36,49 @@ extension FcitxInputController {
     FcitxInputController.inputMethodConfigController.showWindow(nil)
   }
 }
+
+/// All config window controllers should subclass this.  It sets up
+/// application states so that the config windows can receive user
+/// input.
+class ConfigWindowController: NSWindowController, NSWindowDelegate {
+  static var numberOfConfigWindows: Int = 0
+
+  override init(window: NSWindow?) {
+    super.init(window: window)
+    if let window = window {
+      window.delegate = self
+    }
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+
+  override func showWindow(_ sender: Any? = nil) {
+    if let window = window {
+      if !window.isVisible {
+        ConfigWindowController.numberOfConfigWindows += 1
+      }
+
+      window.makeKeyAndOrderFront(nil)
+
+      // Switch to normal activation policy so that the config windows
+      // can receive key events.
+      if NSApp.activationPolicy() != .regular {
+        NSApp.setActivationPolicy(.regular)
+      }
+    }
+  }
+
+  func windowShouldClose(_ sender: NSWindow) -> Bool {
+    sender.orderOut(nil)
+    ConfigWindowController.numberOfConfigWindows -= 1
+
+    // Switch back.
+    if ConfigWindowController.numberOfConfigWindows <= 0 {
+      NSApp.setActivationPolicy(.prohibited)
+      ConfigWindowController.numberOfConfigWindows = 0
+    }
+    return false
+  }
+}


### PR DESCRIPTION
Revert #36's Info.plist change. Still default to LSBackground, but switch to regular activation policy when there is at least one config window.