### PR TITLE
Recreate fcitx input contexts after restarting

### DIFF
--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -225,7 +225,8 @@ bool MacosFrontend::keyEvent(ICUUID uuid, const Key &key, bool isRelease) {
     KeyEvent keyEvent(ic, key, isRelease);
     ic->keyEvent(keyEvent);
 
-    if (simulateKeyRelease_ && !isRelease && !key.isModifier()) {
+    if (simulateKeyRelease_ && !isRelease && !key.isModifier() &&
+        keyEvent.accepted()) {
         auto timeEvent = instance()->eventLoop().addTimeEvent(
             CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + simulateKeyReleaseDelay_,
             10000, [this, ic, key = key](EventSourceTime *source, uint64_t) {

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -218,7 +218,12 @@ void MacosFrontend::selectCandidate(size_t index) {
 
 bool MacosFrontend::keyEvent(ICUUID uuid, const Key &key, bool isRelease) {
     auto *ic = this->findIC(uuid);
-    activeIC_ = ic;
+    if (activeIC_ != ic) {
+        if (activeIC_)
+            activeIC_->focusOut();
+        ic->focusIn();
+        activeIC_ = ic;
+    }
     if (!ic) {
         return false;
     }
@@ -272,6 +277,9 @@ void MacosFrontend::focusIn(ICUUID uuid) {
     if (!ic)
         return;
     ic->focusIn();
+    if (activeIC_)
+        activeIC_->focusOut();
+    activeIC_ = ic;
 }
 
 void MacosFrontend::focusOut(ICUUID uuid) {
@@ -279,6 +287,8 @@ void MacosFrontend::focusOut(ICUUID uuid) {
     if (!ic)
         return;
     ic->focusOut();
+    if (activeIC_ == ic)
+        activeIC_ = nullptr;
 }
 
 } // namespace fcitx

--- a/src/config/menu.swift
+++ b/src/config/menu.swift
@@ -22,6 +22,9 @@ extension FcitxInputController {
 
   @objc func restart(_: Any? = nil) {
     restart_fcitx_thread()
+    for controller in FcitxInputController.registry.allObjects {
+      controller.reconnectToFcitx()
+    }
   }
 
   @objc func about(_: Any? = nil) {

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -40,6 +40,7 @@ class FcitxInputController: IMKInputController {
     // restarting fcitx. So just start a new one here.
     FCITX_DEBUG("Reconnecting to \(appId), client = \(String(describing: client))")
     uuid = create_input_context(appId, client)
+    focus_in(uuid)
   }
 
   // Default behavior is to recognize keyDown only

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -8,7 +8,7 @@ class FcitxInputController: IMKInputController {
   var uuid: ICUUID
   var appId: String
   var lastModifiers = NSEvent.ModifierFlags(rawValue: 0)
-  let client: Any
+  let client: Any!
 
   // A registry of live FcitxInputController objects.
   // Use NSHashTable to store weak references.
@@ -24,7 +24,7 @@ class FcitxInputController: IMKInputController {
     } else {
       appId = ""
     }
-    self.client = client!
+    self.client = client
     uuid = create_input_context(appId, client)
     super.init(server: server, delegate: delegate, client: client)
     FcitxInputController.registry.add(self)

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -40,7 +40,6 @@ class FcitxInputController: IMKInputController {
     // restarting fcitx. So just start a new one here.
     FCITX_DEBUG("Reconnecting to \(appId), client = \(String(describing: client))")
     uuid = create_input_context(appId, client)
-    focus_in(uuid)
   }
 
   // Default behavior is to recognize keyDown only


### PR DESCRIPTION
- After restarting, observe "Reconnecting" debugging logs.
- Quit some apps, and the "Reconnecting" messages for these apps also disappear, meaning the input controllers are successfully reclaimed.