### PR TITLE
Use GroupBox for config subgroups

### DIFF
--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -64,7 +64,9 @@ func jsonToConfig(_ json: JSON, _ pathPrefix: String) throws -> Config {
   // Group
   var children: [Config] = []
   for (key, subJson): (String, JSON) in json {
-    if key == "Value" || key == "Description" || key == "DefaultValue" || key == "Type" {
+    if key == "Value" || key == "Description" || key == "DefaultValue" || key == "Type"
+      || key == "__SortKey"
+    {
       continue
     }
     do {

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -162,7 +162,7 @@ func buildViewImpl(config: Config) -> any View {
       // A subgroup.
       return LabeledContent(config.description) {
         GroupBox {
-          form
+          form.padding()
         }
       }
     }

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -150,41 +150,38 @@ struct ListOptionView: View {
 func buildViewImpl(config: Config) -> any View {
   switch config.kind {
   case .group(let children):
+    let form = Form {
+      ForEach(children) { child in
+        buildView(config: child)
+      }
+    }
     if config.path == "" {
       // Top-level group
-      Form {
-        ForEach(children) { child in
-          buildView(config: child)
-        }
-      }
+      return form
     } else {
       // A subgroup.
-      LabeledContent(config.description) {
+      return LabeledContent(config.description) {
         GroupBox {
-          Form {
-            ForEach(children) { child in
-              buildView(config: child)
-            }
-          }
+          form
         }
       }
     }
 
   case .option(let option):
     if let option = option as? BooleanOption {
-      BooleanOptionView(label: config.description, model: option)
+      return BooleanOptionView(label: config.description, model: option)
     } else if let option = option as? StringOption {
-      StringOptionView(label: config.description, model: option)
+      return StringOptionView(label: config.description, model: option)
     } else if let option = option as? ExternalOption {
-      ExternalOptionView(label: config.description, model: option)
+      return ExternalOptionView(label: config.description, model: option)
     } else if let option = option as? EnumOption {
-      EnumOptionView(label: config.description, model: option)
+      return EnumOptionView(label: config.description, model: option)
     } else if let option = option as? IntegerOption {
-      IntegerOptionView(label: config.description, model: option)
+      return IntegerOptionView(label: config.description, model: option)
     } else if let option = option as? ListOption<String> {
-      ListOptionView(label: config.description, model: option)
+      return ListOptionView(label: config.description, model: option)
     } else {
-      Text("Unsupported option type \(String(describing: option))")
+      return Text("Unsupported option type \(String(describing: option))")
     }
   }
 }

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -150,13 +150,26 @@ struct ListOptionView: View {
 func buildViewImpl(config: Config) -> any View {
   switch config.kind {
   case .group(let children):
-    Form {
-      Section(config.description) {
+    if config.path == "" {
+      // Top-level group
+      Form {
         ForEach(children) { child in
           buildView(config: child)
         }
       }
+    } else {
+      // A subgroup.
+      LabeledContent(config.description) {
+        GroupBox {
+          Form {
+            ForEach(children) { child in
+              buildView(config: child)
+            }
+          }
+        }
+      }
     }
+
   case .option(let option):
     if let option = option as? BooleanOption {
       BooleanOptionView(label: config.description, model: option)


### PR DESCRIPTION
The subgroups are now in a group box:

<img width="878" alt="image" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/23358293/64f017f8-f24f-4634-a2d7-8fead380797e">

This matches the appearance of the upstream fcitx-configtool.