### PR TITLE
fix pressing space to play not work in shotcut

### DIFF
--- a/src/controller.swift
+++ b/src/controller.swift
@@ -86,6 +86,10 @@ class FcitxInputController: IMKInputController {
   }
 
   override func activateServer(_ client: Any!) {
+    // overrideKeyboard is needed for pressing space to play in Shotcut.
+    if let client = client as? IMKTextInput {
+      client.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.ABC")
+    }
     focus_in(uuid)
   }
 


### PR DESCRIPTION
Reproduce:
Open Shotcut, drag a video from Finder to timeline, press space to play.