### PR TITLE
register as Chinese to disable itself on password

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -30,6 +30,9 @@
     <dict>
       <key>org.fcitx.inputmethod.fcitx5</key>
       <dict>
+        <!-- register as Chinese to disable on login/Terminal sudo password input -->
+        <key>TISIntendedLanguage</key>
+        <string>zh-Hans</string>
       </dict>
     </dict>
   </dict>


### PR DESCRIPTION
Tested scenarios:
* In built-in Terminal, type `sudo ls`, switch to double pinyin, hit return.
  * master: Fcitx5 is still used, and backspace won't clear candidate window.
  * PR: fall back to ABC, and Fcitx5 is disabled.
* When double pinyin is activated, lock screen. Input password.
  * master: although not indicated in top bar, Fcitx5 is actually used.
  * PR: ABC is used.

To test this PR, you may need to logout then login, remove Fcitx5 from input method list and re-add it from Simplified Chinese.
I don't think registering for multiple languages is needed, at least for now.
Nor do I want to change background.tiff, as dmg from CI isn't usable at all.