### PR TITLE
fix: close candidate window on deactivate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ WARNING: not ready for any non-developers.
 
 ## Build
 Native build on Intel and Apple Silicon is supported.
-Cross build from Intel to Apple Silicon is performed in [CI](.github/workflows/ci.yml).
 
 ### Install dependencies
 You may use [nvm](https://github.com/nvm-sh/nvm)

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -184,7 +184,7 @@ void MacosFrontend::updateInputPanel(const fcitx::Text &preedit,
 }
 
 /// Before calling this, the panel states must already be initialized
-/// sychronously, by using set_candidates, etc.
+/// synchronously, by using set_candidates, etc.
 void MacosFrontend::showInputPanelAsync(bool show) {
     dispatch_async(dispatch_get_main_queue(), ^void() {
       if (show) {
@@ -283,6 +283,7 @@ void MacosFrontend::focusIn(ICUUID uuid) {
 }
 
 void MacosFrontend::focusOut(ICUUID uuid) {
+    showInputPanelAsync(false);
     auto *ic = findIC(uuid);
     if (!ic)
         return;

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -135,6 +135,9 @@ MacosFrontend::MacosFrontend(Instance *instance)
             case UserInterfaceComponent::InputPanel: {
                 if (activeIC_)
                     activeIC_->updateInputPanel();
+                else
+                    panelShow_ = false; // focus out
+                showInputPanelAsync(panelShow_);
                 break;
             }
             case UserInterfaceComponent::StatusArea: {
@@ -180,7 +183,6 @@ void MacosFrontend::updateInputPanel(const fcitx::Text &preedit,
     updatePanelShowFlags(!preedit.empty(), PanelShowFlag::HasPreedit);
     updatePanelShowFlags(!auxUp.empty(), PanelShowFlag::HasAuxUp);
     updatePanelShowFlags(!auxDown.empty(), PanelShowFlag::HasAuxDown);
-    showInputPanelAsync(panelShow_);
 }
 
 /// Before calling this, the panel states must already be initialized
@@ -207,7 +209,6 @@ void MacosFrontend::updateCandidateList(
     const std::vector<std::string> &labelList, int size, int highlight) {
     window_->set_candidates(candidateList, labelList, highlight);
     updatePanelShowFlags(!candidateList.empty(), PanelShowFlag::HasCandidates);
-    showInputPanelAsync(panelShow_);
 }
 
 void MacosFrontend::selectCandidate(size_t index) {
@@ -283,7 +284,6 @@ void MacosFrontend::focusIn(ICUUID uuid) {
 }
 
 void MacosFrontend::focusOut(ICUUID uuid) {
-    showInputPanelAsync(false);
     auto *ic = findIC(uuid);
     if (!ic)
         return;


### PR DESCRIPTION
Test: open 2 Terminals, type something on one but don't commit to keep candidate window open, then click the other Terminal.
Previous: candidate window is still there, but clicking/pressing space after switching back to the terminal won't commit anything.
Current: candidate window disappears.