### PR TITLE
config: List views

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Lint
         run: |
           find macosfrontend macosnotifications src -name '*.cpp' -o -name '*.h' | xargs clang-format -Werror --dry-run -style=file:fcitx5/.clang-format
-          swift-format lint -rs macosfrontend macosnotifications src
+          swift-format lint --configuration .swift-format.json -rs macosfrontend macosnotifications src
           for file in $(git ls-files | grep '\.swift$'); do
             if grep 'NSLog(' $file; then
               echo "Please use Logging module instead of NSLog"

--- a/.swift-format.json
+++ b/.swift-format.json
@@ -1,0 +1,69 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentation" : {
+    "spaces" : 2
+  },
+  "indentConditionalCompilationBlocks" : true,
+  "indentSwitchCaseLabels" : false,
+  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineLength" : 100,
+  "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "prioritizeKeepingFunctionOutputTogether" : false,
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AlwaysUseLiteralForEmptyCollectionInit" : false,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : false,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "NeverForceUnwrap" : false,
+    "NeverUseForceTry" : false,
+    "NeverUseImplicitlyUnwrappedOptionals" : false,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : false,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : false,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : false,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : false,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : false,
+    "ValidateDocumentationComments" : false
+  },
+  "spacesAroundRangeFormationOperators" : false,
+  "tabWidth" : 8,
+  "version" : 1
+}

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -54,6 +54,21 @@ protocol Option: FcitxCodable {
   func resetToDefault()
 }
 
+struct Identified<T>: Identifiable {
+  var value: T
+  let id = UUID()
+}
+
+extension Identified: FcitxCodable where T: FcitxCodable {
+  static func decode(json: JSON) throws -> Self {
+    return Identified(value: try T.decode(json: json))
+  }
+
+  func encodeValueJSON() -> JSON {
+    return value.encodeValueJSON()
+  }
+}
+
 class SimpleOption<T: FcitxCodable>: Option, ObservableObject {
   let defaultValue: T
   @Published var value: T
@@ -162,12 +177,12 @@ extension EnumOption: CustomStringConvertible {
 
 class ListOption<T: FcitxCodable>: Option, ObservableObject {
   let defaultValue: [T]
-  @Published var value: [T]
+  @Published var value: [Identified<T>]
   let elementType: String
 
   required init(defaultValue: [T], value: [T]?, elementType: String) {
     self.defaultValue = defaultValue
-    self.value = value ?? defaultValue
+    self.value = (value ?? defaultValue).map { Identified(value: $0) }
     self.elementType = elementType
   }
 
@@ -184,7 +199,7 @@ class ListOption<T: FcitxCodable>: Option, ObservableObject {
   }
 
   func resetToDefault() {
-    value = defaultValue
+    value = defaultValue.map { Identified(value: $0) }
   }
 }
 


### PR DESCRIPTION
<img width="1277" alt="image" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/23358293/fde747fd-b6f4-4aff-8764-ca2548bd51aa">

(↑ `List|Key` currently displayed as string list.)

Elements can be added, removed, reordered, and edited. `Save` also works. For example: swap `minus` and `equalsign` in "Prev cand" and "Next cand"; add `semicolon` as "Select second cand"; add `apostrophe` as "Select third cand". After saving, these keys will work.