### PR TITLE
auto restart on plugin install/uninstall

### DIFF
--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -220,14 +220,12 @@ void MacosFrontend::selectCandidate(size_t index) {
 
 bool MacosFrontend::keyEvent(ICUUID uuid, const Key &key, bool isRelease) {
     auto *ic = this->findIC(uuid);
-    if (activeIC_ != ic) {
-        if (activeIC_)
-            activeIC_->focusOut();
-        ic->focusIn();
-        activeIC_ = ic;
-    }
     if (!ic) {
         return false;
+    }
+    if (activeIC_ != ic) {
+        ic->focusIn();
+        activeIC_ = ic;
     }
     KeyEvent keyEvent(ic, key, isRelease);
     ic->keyEvent(keyEvent);

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -3,6 +3,7 @@ import Logging
 import SwiftUI
 
 class InputMethodConfigController: ConfigWindowController {
+  let view = InputMethodConfigView()
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
@@ -11,11 +12,15 @@ class InputMethodConfigController: ConfigWindowController {
     window.title = "Input Methods"
     window.center()
     self.init(window: window)
-    window.contentView = NSHostingView(rootView: InputMethodConfigView())
+    window.contentView = NSHostingView(rootView: view)
     window.level = .floating
     window.titlebarAppearsTransparent = true
     window.toolbar?.showsBaselineSeparator = false
     window.toolbarStyle = .unified
+  }
+
+  func refresh() {
+    view.refresh()
   }
 }
 
@@ -52,7 +57,7 @@ private struct GroupItem: Identifiable, Codable {
 }
 
 struct InputMethodConfigView: View {
-  @StateObject private var viewModel = ViewModel()
+  @ObservedObject private var viewModel = ViewModel()
   @StateObject var addGroupDialog = InputDialog(title: "Add an empty group", prompt: "Group name")
   @StateObject var renameGroupDialog = InputDialog(title: "Rename group", prompt: "Group name")
 
@@ -162,6 +167,10 @@ struct InputMethodConfigView: View {
     }
   }
 
+  func refresh() {
+    viewModel.load()
+  }
+
   private class ViewModel: ObservableObject {
     @Published var groups = [Group]()
     @Published var selectedItem: UUID? {
@@ -177,10 +186,6 @@ struct InputMethodConfigView: View {
     @Published var configModel: Config?
     @Published var errorMsg: String?
     var uuidToIM = [UUID: String]()
-
-    init() {
-      load()
-    }
 
     func load() {
       groups = []

--- a/src/config/menu.swift
+++ b/src/config/menu.swift
@@ -1,6 +1,13 @@
 import Cocoa
 import Fcitx
 
+func restartAndReconnect() {
+  restart_fcitx_thread()
+  for controller in FcitxInputController.registry.allObjects {
+    controller.reconnectToFcitx()
+  }
+}
+
 extension FcitxInputController {
   static var fcitxAbout: NSWindowController = {
     return FcitxAbout()
@@ -21,10 +28,7 @@ extension FcitxInputController {
   }
 
   @objc func restart(_: Any? = nil) {
-    restart_fcitx_thread()
-    for controller in FcitxInputController.registry.allObjects {
-      controller.reconnectToFcitx()
-    }
+    restartAndReconnect()
   }
 
   @objc func about(_: Any? = nil) {
@@ -36,6 +40,7 @@ extension FcitxInputController {
   }
 
   @objc func inputMethod(_: Any? = nil) {
+    FcitxInputController.inputMethodConfigController.refresh()
     FcitxInputController.inputMethodConfigController.showWindow(nil)
   }
 }

--- a/src/config/plugin.swift
+++ b/src/config/plugin.swift
@@ -168,6 +168,7 @@ struct PluginView: View {
     }
     selectedInstalled.removeAll()
     refreshPlugins()
+    restartAndReconnect()
     processing = false
   }
 
@@ -246,6 +247,7 @@ struct PluginView: View {
       }
       installResults.removeAll()
       refreshPlugins()
+      restartAndReconnect()
       processing = false
     }
   }
@@ -279,7 +281,7 @@ struct PluginView: View {
   }
 }
 
-class PluginManager: NSWindowController {
+class PluginManager: ConfigWindowController {
   let view = PluginView()
   convenience init() {
     let window = NSWindow(

--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -102,12 +102,10 @@ void Fcitx::setupInstance() {
     auto &addonMgr = instance_->addonManager();
     addonMgr.registerDefaultLoader(&staticAddons);
     instance_->initialize();
+    dispatcher_->attach(&instance_->eventLoop());
 }
 
-void Fcitx::exec() {
-    dispatcher_->attach(&instance_->eventLoop());
-    instance_->exec();
-}
+void Fcitx::exec() { instance_->exec(); }
 
 void Fcitx::exit() {
     // the fcitx instance may have been destroyed by stop_fcitx_thread.


### PR DESCRIPTION
Caveats for reviewer to try and confirm:
* For `viewModel` to auto update view, it has to be a `ObservedObject` instead of `StateObject`.
* `dispatcher_->attach` has to be executed in main thread to ensure it's executed before https://github.com/fcitx-contrib/fcitx5-macos/blob/54a78bb2562b82591606eddee0466bc71447816c/src/fcitx.h#L57
otherwise `fut.wait()` may hang. This may happen when you install a plugin and type in another window at the same time.

Normal test procedure:
* Open Input Methods, see no Thai IM in Thai Lang. Close.
* Install thai in Plugin Manager.
* Reopen Input Methods and add Thai IM. Confirm it works by `l;ylfu` which is สวัสดี. Close.
* Uninstall thai.
* Reopen Input Methods and see Thai disappear.