### PR TITLE
fix(config): save input method info after reorder

### DIFF
--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -124,10 +124,6 @@ struct InputMethodConfigView: View {
             }
           }
         }
-        .onMove { indices, newOffset in
-          viewModel.groups.move(fromOffsets: indices, toOffset: newOffset)
-          viewModel.save()
-        }
       }
       .contextMenu {
         Button("Add group") {

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -120,11 +120,13 @@ struct InputMethodConfigView: View {
             }
             .onMove { indices, newOffset in
               group.inputMethods.move(fromOffsets: indices, toOffset: newOffset)
+              viewModel.save()
             }
           }
         }
         .onMove { indices, newOffset in
           viewModel.groups.move(fromOffsets: indices, toOffset: newOffset)
+          viewModel.save()
         }
       }
       .contextMenu {


### PR DESCRIPTION
fix "Bug: changing input methods order doesn't affect their order in system menu"