### PR TITLE
implement addon config

### DIFF
--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -44,6 +44,11 @@ public:
     void reloadConfig() override;
     void save() override;
     const Configuration *getConfig() const override { return &config_; }
+    void setConfig(const RawConfig &config) override {
+        config_.load(config, true);
+        safeSaveAsIni(config_, ConfPath);
+        updateConfig();
+    }
 
     void updateCandidateList(const std::vector<std::string> &candidates,
                              const std::vector<std::string> &labels, int size,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB CONFIG_UI_FILES config/*.swift)
+file(GLOB CONFIG_UI_FILES CONFIGURE_DEPENDS config/*.swift)
 
 add_library(Fcitx5Objs STATIC
     fcitx.cpp

--- a/src/config/addonconfig.swift
+++ b/src/config/addonconfig.swift
@@ -1,0 +1,121 @@
+import Fcitx
+import Logging
+import SwiftUI
+
+class AddonConfigController: ConfigWindowController {
+  let view = AddonConfigView()
+
+  convenience init() {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+      styleMask: [.titled, .closable],
+      backing: .buffered, defer: false)
+    window.title = "Addon Config"
+    window.center()
+    self.init(window: window)
+    window.contentView = NSHostingView(rootView: view)
+  }
+
+  func refresh() {
+    view.refresh()
+  }
+}
+
+private struct Addon: Codable, Identifiable {
+  let name: String
+  let id: String
+  let comment: String
+  let isConfigurable: Bool
+}
+
+private struct Category: Codable, Identifiable {
+  let name: String
+  let id: Int
+  let addons: [Addon]
+}
+
+private struct AddonRowView: View {
+  var addon: Addon
+  @StateObject private var viewModel = ExternalConfigViewModel()
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      HStack {
+        Text(addon.name).font(.headline)
+        if addon.isConfigurable {
+          Spacer()
+          Button("Setting", systemImage: "gearshape", action: openSetting).labelStyle(.iconOnly)
+            .sheet(isPresented: $viewModel.hasConfig) {
+              VStack {
+                ScrollView([.horizontal, .vertical]) {
+                  buildView(config: viewModel.externalConfig!)
+                }
+                HStack {
+                  Button("Save") {
+                    viewModel.saveExternalConfig("fcitx://config/addon/\(addon.id)/")
+                  }
+                  Button("Close") {
+                    viewModel.externalConfig = nil
+                  }
+                }
+              }
+              .padding()
+              .frame(minWidth: 400)
+            }
+        }
+      }
+      if !addon.comment.isEmpty {
+        Text(addon.comment)
+      }
+    }.padding()
+  }
+
+  private func openSetting() {
+    viewModel.showConfig("fcitx://config/addon/\(addon.id)/")
+  }
+}
+
+struct AddonConfigView: View {
+  @ObservedObject private var viewModel = ViewModel()
+
+  var body: some View {
+    List {
+      ForEach(viewModel.categories) { category in
+        Section(header: Text(category.name)) {
+          ForEach(category.addons) { addon in
+            AddonRowView(addon: addon)
+          }
+        }
+      }
+    }
+  }
+
+  func refresh() {
+    viewModel.load()
+  }
+
+  private class ViewModel: ObservableObject {
+    @Published var categories = [Category]()
+    @Published var hasError = false
+    var errorMsg: String? {
+      didSet {
+        hasError = (errorMsg != nil)
+      }
+    }
+
+    func load() {
+      do {
+        let jsonStr = String(Fcitx.getAddons())
+        if let jsonData = jsonStr.data(using: .utf8) {
+          categories = try JSONDecoder().decode([Category].self, from: jsonData)
+        } else {
+          errorMsg = "Couldn't decode addon config: not UTF-8"
+          FCITX_ERROR(errorMsg!)
+        }
+      } catch {
+        errorMsg = "Couldn't load addon config: \(error)"
+        FCITX_ERROR(errorMsg!)
+      }
+    }
+  }
+}

--- a/src/config/menu.swift
+++ b/src/config/menu.swift
@@ -21,6 +21,9 @@ extension FcitxInputController {
   static var inputMethodConfigController: InputMethodConfigController = {
     return InputMethodConfigController()
   }()
+  static var addonConfigController: AddonConfigController = {
+    return AddonConfigController()
+  }()
 
   @objc func plugin(_: Any? = nil) {
     FcitxInputController.pluginManager.refreshPlugins()
@@ -42,6 +45,11 @@ extension FcitxInputController {
   @objc func inputMethod(_: Any? = nil) {
     FcitxInputController.inputMethodConfigController.refresh()
     FcitxInputController.inputMethodConfigController.showWindow(nil)
+  }
+
+  @objc func addonConfig(_: Any? = nil) {
+    FcitxInputController.addonConfigController.refresh()
+    FcitxInputController.addonConfigController.showWindow(nil)
   }
 }
 

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -153,6 +153,7 @@ class FcitxInputController: IMKInputController {
 
     menu.addItem(withTitle: "Input Methods", action: #selector(inputMethod(_:)), keyEquivalent: "")
     menu.addItem(withTitle: "Global Config", action: #selector(globalConfig(_:)), keyEquivalent: "")
+    menu.addItem(withTitle: "Addon Config", action: #selector(addonConfig(_:)), keyEquivalent: "")
     menu.addItem(withTitle: "Plugin Manager", action: #selector(plugin(_:)), keyEquivalent: "")
     menu.addItem(withTitle: "Restart", action: #selector(restart(_:)), keyEquivalent: "")
     menu.addItem(withTitle: "About Fcitx5 macOS", action: #selector(about(_:)), keyEquivalent: "")

--- a/src/fcitx-public.h
+++ b/src/fcitx-public.h
@@ -39,6 +39,8 @@ void imSetCurrentIM(const char *imName) noexcept;
 // languageCode:str, icon:str, label:str, isConfigurable: bool}
 std::string imGetAvailableIMs() noexcept;
 
+std::string getAddons() noexcept;
+
 std::string getActions() noexcept;
 void activateActionById(int id) noexcept;
 


### PR DESCRIPTION
Reference:
* Producer: https://github.com/fcitx/fcitx5/blob/b8d5038913b4227c5ca72d7c7ed80cab32f6b39d/src/modules/dbus/dbusmodule.cpp#L445
* Consumer: https://github.com/fcitx/fcitx5-configtool/blob/39d826e6f818c7c7df05f3861bb52ad44c4d351c/src/lib/configlib/addonmodel.cpp#L27

Test:
* Rime: `Fix embedded preedit cursor at the beginning of preedit` works.
* macOS Frontend: `Simulate key release` works.

I only reused view model. If view (sheet) could be reused that would be better.