### PR TITLE
disallow horizontal ScrollView

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
               echo "Please use Logging module instead of NSLog"
               exit 1
             fi
+            if grep 'ScrollView.*\.horizontal' $file; then
+              echo "Please don't use horizontal scroll"
+              exit 1
+            fi
           done
 
   build:

--- a/src/config/addonconfig.swift
+++ b/src/config/addonconfig.swift
@@ -47,7 +47,7 @@ private struct AddonRowView: View {
           Button("Setting", systemImage: "gearshape", action: openSetting).labelStyle(.iconOnly)
             .sheet(isPresented: $viewModel.hasConfig) {
               VStack {
-                ScrollView([.horizontal, .vertical]) {
+                ScrollView([.vertical]) {
                   buildView(config: viewModel.externalConfig!)
                 }
                 HStack {

--- a/src/config/inputmethod.swift
+++ b/src/config/inputmethod.swift
@@ -140,7 +140,7 @@ struct InputMethodConfigView: View {
       if let selectedItem = viewModel.selectedItem {
         if let configModel = viewModel.configModel {
           VStack {
-            let scrollView = ScrollView([.vertical, .horizontal]) {
+            let scrollView = ScrollView([.vertical]) {
               buildView(config: configModel)
             }
             if #available(macOS 14.0, *) {

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -119,7 +119,7 @@ struct ExternalOptionView: View {
     }
     .sheet(isPresented: $viewModel.hasConfig) {
       VStack {
-        ScrollView([.horizontal, .vertical]) {
+        ScrollView([.vertical]) {
           buildView(config: viewModel.externalConfig!)
         }
         HStack {


### PR DESCRIPTION
Reproduce: drag window horizontally so that horizontal scrollbar disappears, then clicking checkbox won't get a response. The actual click region that can respond is shifted right.
Horizontal scroll itself is usually bad UX anyway, so worth making a rule.