### PR TITLE
ui config: follow cursor

### DIFF
--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -141,9 +141,10 @@ void MacosInputContext::updatePreeditImpl() {
     SwiftFrontend::setPreedit(client_, preedit.toString(), preedit.cursor());
 }
 
-std::pair<double, double> MacosInputContext::getCursorCoordinates() {
+std::pair<double, double>
+MacosInputContext::getCursorCoordinates(bool followCursor) {
     double x = 0, y = 0;
-    if (!SwiftFrontend::getCursorCoordinates(client_, &x, &y)) {
+    if (!SwiftFrontend::getCursorCoordinates(client_, followCursor, &x, &y)) {
         FCITX_WARN() << "Failed to get cursor coordinates";
     }
     return std::make_pair(x, y);

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -84,7 +84,7 @@ public:
     void forwardKeyImpl(const ForwardKeyEvent &key) override {}
     void updatePreeditImpl() override;
 
-    std::pair<double, double> getCursorCoordinates();
+    std::pair<double, double> getCursorCoordinates(bool followCursor);
     id client() { return client_; }
 
 private:

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -136,9 +136,11 @@ void WebPanel::showAsync(bool show) {
       if (show) {
           if (auto ic = dynamic_cast<MacosInputContext *>(
                   instance_->mostRecentInputContext())) {
-              // showPreeditCallback is executed before candidateListCallback,
-              // so in main thread preedit UI update happens before here.
-              auto [x, y] = ic->getCursorCoordinates();
+              // MacosInputContext::updatePreeditImpl is executed before
+              // WebPanel::update, so in main thread preedit UI update happens
+              // before here.
+              auto [x, y] =
+                  ic->getCursorCoordinates(config_.followCursor.value());
               window_->show(x, y);
           }
       } else {

--- a/webpanel/webpanel.h
+++ b/webpanel/webpanel.h
@@ -29,6 +29,7 @@ FCITX_CONFIGURATION(
 
     OptionWithAnnotation<std::string, NoSaveAnnotation> preview{
         this, "Preview", _("Type here to preview style")};
+    Option<bool> followCursor{this, "FollowCursor", _("Follow cursor"), false};
     Option<candidate_window::theme_t> theme{this, "Theme", _("Theme"),
                                             candidate_window::theme_t::system};
     Option<candidate_window::layout_t> layout{


### PR DESCRIPTION
@wengxt said 顶功 lovers need this feature, though Squirrel [doesn't seem to have](https://github.com/rime/squirrel/blob/3d70c75e4150cf73fefcf7d04a61066761c31ccf/SquirrelInputController.m#L466) this. Has anyone complained about that?
Anyway this should be disabled by default.
I've noticed some cases that valid index results in (0,0) as well, but I don't think it needs to be resolved here, as the algorithm is hacky.