### PR TITLE
fix focusIn->focusOut on the same IC

### DIFF
--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -64,7 +64,6 @@ private:
     static const inline std::string ConfPath = "conf/macosfrontend.conf";
 
     FocusGroup focusGroup_; // ensure there is at most one active ic
-    MacosInputContext *activeIC_;
     std::vector<std::unique_ptr<HandlerTableEntry<EventHandler>>>
         eventHandlers_;
 


### PR DESCRIPTION
An attempt to fix a race condition about focusin and focusout on the same IC, experienced in Telegram: sometimes focusOut will be sent after focusIn on the same IC. This PR fully delegates the work of `activeIC_` to `FocusGroup`, and makes sure the IC is focused in when handling keyEvent.