### PR TITLE
ui config: highlight color and panel color

### DIFF
--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -86,6 +86,8 @@ private func jsonToOption(_ json: JSON, _ type: String) throws -> any Option {
     return try EnumOption.decode(json: json)
   } else if type == "Key" {
     return try KeyOption.decode(json: json)
+  } else if type == "Color" {
+    return try ColorOption.decode(json: json)
   } else if type == "List|String" {
     return try ListOption<String>.decode(json: json)
   } else if type == "List|Key" {

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -29,17 +29,19 @@ struct StringOptionView: OptionView {
   }
 }
 
+let numberFormatter: NumberFormatter = {
+  let formatter = NumberFormatter()
+  formatter.numberStyle = .decimal
+  formatter.allowsFloats = false
+  formatter.usesGroupingSeparator = false
+  return formatter
+}()
+
 struct IntegerOptionView: OptionView {
   let label: String
   let overrideLabel: String? = nil
   @ObservedObject var model: IntegerOption
-  let numberFormatter: NumberFormatter = {
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .decimal
-    formatter.allowsFloats = false
-    formatter.usesGroupingSeparator = false
-    return formatter
-  }()
+
   var body: some View {
     ZStack(alignment: .trailing) {
       TextField(label, value: $model.value, formatter: numberFormatter)
@@ -66,6 +68,26 @@ struct IntegerOptionView: OptionView {
           model.value += 1
         } label: {
           Image(systemName: "plus")
+        }
+      }
+    }
+  }
+}
+
+struct ColorOptionView: OptionView {
+  let label: String
+  let overrideLabel: String? = nil
+  @ObservedObject var model: ColorOption
+  var body: some View {
+    HStack {
+      ColorPicker("", selection: $model.rgb, supportsOpacity: true)
+      Text("Alpha (0-255)")
+      TextField("", value: $model.alpha, formatter: numberFormatter).onChange(of: model.alpha) {
+        newValue in
+        if newValue > 255 {
+          model.alpha = 255
+        } else if newValue < 0 {
+          model.alpha = 0
         }
       }
     }
@@ -318,6 +340,8 @@ func buildViewImpl(config: Config) -> any OptionView {
       return EnumOptionView(label: config.description, model: option)
     } else if let option = option as? IntegerOption {
       return IntegerOptionView(label: config.description, model: option)
+    } else if let option = option as? ColorOption {
+      return ColorOptionView(label: config.description, model: option)
     } else if let option = option as? ListOption<String> {
       return StringListOptionView(label: config.description, model: option)
     } else {

--- a/webpanel/webpanel.h
+++ b/webpanel/webpanel.h
@@ -24,6 +24,25 @@ struct NoSaveAnnotation {
     void dumpDescription(RawConfig &config) const {}
 };
 
+FCITX_CONFIGURATION(LightModeConfig,
+                    Option<bool> overrideDefault{this, "OverrideDefault",
+                                                 _("Override default"), false};
+                    Option<Color> highlightColor{this, "HighlightColor",
+                                                 "Highlight color",
+                                                 Color(0, 0, 255, 255)};
+                    Option<Color> panelColor{this, "PanelColor", "Panel color",
+                                             Color(255, 255, 255, 255)};);
+
+FCITX_CONFIGURATION(
+    DarkModeConfig, Option<bool> overrideDefault{this, "OverrideDefault",
+                                                 _("Override default"), false};
+    Option<bool> sameWithLightMode{this, "SameWithLightMode",
+                                   _("Same with light mode"), false};
+    Option<Color> highlightColor{this, "HighlightColor", "Highlight color",
+                                 Color(0, 0, 255, 255)};
+    Option<Color> panelColor{this, "PanelColor", "Panel color",
+                             Color(255, 255, 255, 255)};);
+
 FCITX_CONFIGURATION(
     WebPanelConfig,
 
@@ -32,6 +51,8 @@ FCITX_CONFIGURATION(
     Option<bool> followCursor{this, "FollowCursor", _("Follow cursor"), false};
     Option<candidate_window::theme_t> theme{this, "Theme", _("Theme"),
                                             candidate_window::theme_t::system};
+    Option<LightModeConfig> lightMode{this, "LightMode", _("Light mode")};
+    Option<DarkModeConfig> darkMode{this, "DarkMode", _("Dark mode")};
     Option<candidate_window::layout_t> layout{
         this, "Layout", _("Layout"), candidate_window::layout_t::horizontal};
     Option<bool> backgroundBlur{this, "BackgroundBlur", _("Background blur"),


### PR DESCRIPTION
Hack: a `ColorOption` maps to a `ColorPicker` and a `TextField`.
Ideally more code could be reused from IntegerOptionView for alpha, but given we aim to remove the hack later, it's not worth over-engineering right now.