### PR TITLE
force a dummy client preedit

### DIFF
--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -129,7 +129,17 @@ void MacosInputContext::commitStringImpl(const std::string &text) {
 void MacosInputContext::updatePreeditImpl() {
     auto preedit =
         frontend_->instance()->outputFilter(this, inputPanel().clientPreedit());
+    preeditEmpty = preedit.empty();
     SwiftFrontend::setPreedit(client_, preedit.toString(), preedit.cursor());
+}
+
+void MacosInputContext::forcePreedit(bool show) {
+    if (preeditEmpty) {
+        // Without client preedit, Backspace bypasses IM in Terminal, every key
+        // is both processed by IM and passed to client in iTerm, so we force a
+        // dummy client preedit here.
+        SwiftFrontend::setPreedit(client_, show ? " " : "", 0);
+    }
 }
 
 std::pair<double, double>

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -82,6 +82,7 @@ public:
     void deleteSurroundingTextImpl(int offset, unsigned int size) override {}
     void forwardKeyImpl(const ForwardKeyEvent &key) override {}
     void updatePreeditImpl() override;
+    void forcePreedit(bool show);
 
     std::pair<double, double> getCursorCoordinates(bool followCursor);
     id client() { return client_; }
@@ -89,6 +90,7 @@ public:
 private:
     MacosFrontend *frontend_;
     id client_;
+    bool preeditEmpty = true; // the fake preedit doesn't count here
 };
 
 class MacosFrontendFactory : public AddonFactory {

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -102,9 +102,10 @@ void WebPanel::update(UserInterfaceComponent component,
         window_->set_candidates(candidates, labels, highlighted);
         window_->set_layout(layout);
         updatePanelShowFlags(!candidates.empty(), PanelShowFlag::HasCandidates);
-        dynamic_cast<MacosInputContext *>(inputContext)
-            ->forcePreedit((panelShow_ & PanelShowFlag::HasPreedit) |
-                           (panelShow_ & PanelShowFlag::HasCandidates));
+        if (auto macosIC = dynamic_cast<MacosInputContext *>(inputContext)) {
+            macosIC->forcePreedit((panelShow_ & PanelShowFlag::HasPreedit) |
+                                  (panelShow_ & PanelShowFlag::HasCandidates));
+        }
         showAsync(panelShow_);
         break;
     }

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -102,6 +102,9 @@ void WebPanel::update(UserInterfaceComponent component,
         window_->set_candidates(candidates, labels, highlighted);
         window_->set_layout(layout);
         updatePanelShowFlags(!candidates.empty(), PanelShowFlag::HasCandidates);
+        dynamic_cast<MacosInputContext *>(inputContext)
+            ->forcePreedit((panelShow_ & PanelShowFlag::HasPreedit) |
+                           (panelShow_ & PanelShowFlag::HasPreedit));
         showAsync(panelShow_);
         break;
     }

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -104,7 +104,7 @@ void WebPanel::update(UserInterfaceComponent component,
         updatePanelShowFlags(!candidates.empty(), PanelShowFlag::HasCandidates);
         dynamic_cast<MacosInputContext *>(inputContext)
             ->forcePreedit((panelShow_ & PanelShowFlag::HasPreedit) |
-                           (panelShow_ & PanelShowFlag::HasPreedit));
+                           (panelShow_ & PanelShowFlag::HasCandidates));
         showAsync(panelShow_);
         break;
     }


### PR DESCRIPTION
To reproduce on master, set `Preedit Mode` to `Do not show` in rime, then confirm that Backspace bypasses IM in Terminal, and there is an annoying echo in iTerm.

![IMAGE 2024-02-26 00:02:55](https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/a0c7c928-a272-42e4-9c7e-070a97d18970)
