### PR TITLE
config: support List|Enum

### DIFF
--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -93,6 +93,8 @@ private func jsonToOption(_ json: JSON, _ type: String) throws -> any Option {
   } else if type == "List|Key" {
     // TODO
     return try ListOption<StringOption>.decode(json: json)
+  } else if type == "List|Enum" {
+    return try ListOption<EnumOption>.decode(json: json)
   } else if type == "External" {
     return try ExternalOption.decode(json: json)
   } else {

--- a/src/config/config.swift
+++ b/src/config/config.swift
@@ -89,10 +89,10 @@ private func jsonToOption(_ json: JSON, _ type: String) throws -> any Option {
   } else if type == "Color" {
     return try ColorOption.decode(json: json)
   } else if type == "List|String" {
-    return try ListOption<String>.decode(json: json)
+    return try ListOption<StringOption>.decode(json: json)
   } else if type == "List|Key" {
     // TODO
-    return try ListOption<String>.decode(json: json)
+    return try ListOption<StringOption>.decode(json: json)
   } else if type == "External" {
     return try ExternalOption.decode(json: json)
   } else {
@@ -218,6 +218,22 @@ extension Optional: FcitxCodable where Wrapped: FcitxCodable {
     } else {
       return JSON()
     }
+  }
+}
+
+struct UnusedCodable {}
+
+extension UnusedCodable: FcitxCodable {
+  static func decode(json: JSON) throws -> Self {
+    // should never be decoded
+    assert(false)
+    return UnusedCodable()
+  }
+
+  func encodeValueJSON() -> JSON {
+    // Should never be encoded
+    assert(false)
+    return JSON()
   }
 }
 

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -157,12 +157,7 @@ class ColorOption: Option, ObservableObject {
     let rgb = value ?? defaultValue
     self.rgb = rgb
     self.alpha = Int(round(rgb.cgColor!.components![3] * 255.0))
-    self.value = value ?? defaultValue
-  }
-
-  func updateRGBA() {
-    rgb = value
-    alpha = Int(round(rgb.cgColor!.components![3] * 255.0))
+    self.value = rgb
   }
 
   func updateColor() {
@@ -182,8 +177,8 @@ class ColorOption: Option, ObservableObject {
   }
 
   func resetToDefault() {
-    value = defaultValue
-    updateRGBA()
+    rgb = defaultValue
+    alpha = Int(round(rgb.cgColor!.components![3] * 255.0))
   }
 }
 

--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -144,9 +144,7 @@ class ColorOption: Option, ObservableObject {
   typealias Storage = Color
   let defaultValue: Color
   // Prior to macOS 14.0, ColorPicker doesn't support alpha
-  var value: Color {
-    didSet { updateRGBA() }
-  }
+  var value: Color
   @Published var rgb: Color {
     didSet { updateColor() }
   }
@@ -185,6 +183,7 @@ class ColorOption: Option, ObservableObject {
 
   func resetToDefault() {
     value = defaultValue
+    updateRGBA()
   }
 }
 

--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -199,7 +199,7 @@ struct EnumOptionView: OptionView {
 struct StringListOptionView: OptionView {
   let label: String
   let overrideLabel: String? = nil
-  @ObservedObject var model: ListOption<String>
+  @ObservedObject var model: ListOption<StringOption>
 
   var body: some View {
     VStack {
@@ -342,7 +342,7 @@ func buildViewImpl(config: Config) -> any OptionView {
       return IntegerOptionView(label: config.description, model: option)
     } else if let option = option as? ColorOption {
       return ColorOptionView(label: config.description, model: option)
-    } else if let option = option as? ListOption<String> {
+    } else if let option = option as? ListOption<StringOption> {
       return StringListOptionView(label: config.description, model: option)
     } else {
       return UnsupportedOptionView(model: option)
@@ -379,7 +379,8 @@ let testConfig = Config(
     Config(
       path: "list", description: "List test",
       kind: .option(
-        ListOption(defaultValue: ["a", "b", "c"], value: ["c", "d"], elementType: "String"))
+        ListOption<StringOption>(
+          defaultValue: ["a", "b", "c"], value: ["c", "d"], elementType: "String"))
     ),
   ]))
 


### PR DESCRIPTION
Parametrize `ListOptionView` by `Option` instead of the underlying storage types, which should make supporting other element types easier. Adding empty elements is handled by adding a new protocol `EmptyConstructible`.