### PR TITLE
fix auto-added im not saved

### DIFF
--- a/src/fcitx.cpp
+++ b/src/fcitx.cpp
@@ -239,6 +239,7 @@ void imAddToCurrentGroup(const char *imName) noexcept {
         auto group = imMgr.currentGroup();
         group.inputMethodList().emplace_back(imName);
         imMgr.setGroup(group);
+        imMgr.save();
     });
 }
 


### PR DESCRIPTION
Reproduce: make sure there is only one group, uninstall hallelujah plugin, install hallelujah plugin, switch to hallelujah, use it, `pkill Fcitx5`, then hallelujah disappears from current IM list.