### PR TITLE
fix forcing the leading 3 of 30 to be 4 when int option is 4 to 100

### DIFF
--- a/src/config/optionviews.swift
+++ b/src/config/optionviews.swift
@@ -41,35 +41,45 @@ struct IntegerOptionView: OptionView {
   let label: String
   let overrideLabel: String? = nil
   @ObservedObject var model: IntegerOption
+  @FocusState private var isFocused: Bool
 
   var body: some View {
     ZStack(alignment: .trailing) {
       TextField(label, value: $model.value, formatter: numberFormatter)
+        .focused($isFocused)
         .textFieldStyle(RoundedBorderTextFieldStyle())
-        .onChange(of: model.value) { newValue in
-          if let max = model.max,
-            newValue > max
-          {
-            model.value = max
-          } else if let min = model.min,
-            newValue < min
-          {
-            model.value = min
+        .onChange(of: isFocused) { newValue in
+          if !newValue {  // lose focus
+            validate()
           }
         }
         .padding(.trailing, 60)
       HStack(spacing: 0) {
         Button {
           model.value -= 1
+          validate()
         } label: {
           Image(systemName: "minus")
         }
         Button {
           model.value += 1
+          validate()
         } label: {
           Image(systemName: "plus")
         }
       }
+    }
+  }
+
+  func validate() {
+    if let max = model.max,
+      model.value > max
+    {
+      model.value = max
+    } else if let min = model.min,
+      model.value < min
+    {
+      model.value = min
     }
   }
 }


### PR DESCRIPTION
This is something that needs to be handled but I don't know the best practice so feel free to change to a better solution.
On master when you want to set font size to 30 you type 3 first, but since it's less than 4, it's automatically converted to 4, which is bad UX.