### PR TITLE
ui config: hover behavior of 3 desktop OSs

### DIFF
--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -32,9 +32,9 @@ void WebPanel::updateConfig() {
     window_->set_cursor_text(config_.cursor->style.value() == CursorStyle::Text
                                  ? config_.cursor->text.value()
                                  : "");
-    window_->set_highlight_mark_text(config_.highlightMark->style.value() ==
+    window_->set_highlight_mark_text(config_.highlight->markStyle.value() ==
                                              HighlightMarkStyle::Text
-                                         ? config_.highlightMark->text.value()
+                                         ? config_.highlight->markText.value()
                                          : "");
     config_.preview.setValue("");
     auto style = configValueToJson(config_).dump();

--- a/webpanel/webpanel.h
+++ b/webpanel/webpanel.h
@@ -26,6 +26,10 @@ enum class HighlightMarkStyle { None, Bar, Text };
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(HighlightMarkStyle, N_("None"), N_("Bar"),
                                  N_("Text"))
 
+enum class HoverBehavior { None, Move, Add };
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(HoverBehavior, N_("None"), N_("Move"),
+                                 N_("Add"))
+
 namespace fcitx {
 
 struct NoSaveAnnotation {
@@ -128,10 +132,13 @@ FCITX_CONFIGURATION(CursorConfig,
                                               CursorStyle::Blink};
                     Option<std::string> text{this, "Text", _("Text"), "‸"};);
 
-FCITX_CONFIGURATION(HighlightMarkConfig,
-                    Option<HighlightMarkStyle> style{this, "Style", _("Style"),
-                                                     HighlightMarkStyle::None};
-                    Option<std::string> text{this, "Text", _("Text"), ""};);
+FCITX_CONFIGURATION(
+    HighlightConfig,
+    Option<HighlightMarkStyle> markStyle{this, "MarkStyle", _("Mark style"),
+                                         HighlightMarkStyle::None};
+    Option<std::string> markText{this, "MarkText", _("Mark text"), "🐧"};
+    Option<HoverBehavior> hoverBehavior{
+        this, "HoverBehavior", _("Hover behavior"), HoverBehavior::None};);
 
 FCITX_CONFIGURATION(
     Size,
@@ -176,8 +183,7 @@ FCITX_CONFIGURATION(
     Option<BackgroundConfig> background{this, "Background", _("Background")};
     Option<FontConfig> font{this, "Font", _("Font")};
     Option<CursorConfig> cursor{this, "Cursor", _("Cursor")};
-    Option<HighlightMarkConfig> highlightMark{this, "HighlightMark",
-                                              _("Highlight mark")};
+    Option<HighlightConfig> highlight{this, "Highlight", _("Highlight")};
     Option<Size> size{this, "Size", _("Size")};);
 
 enum class PanelShowFlag : int;


### PR DESCRIPTION
This is Move mode, same with fcitx5 Linux.

https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/c352d995-4f59-473d-87a2-e5f5cc8c6cad

This is Add mode, same with MSPY.

https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/857ea75a-60a2-4b7a-88c7-b99113a09d7e

Please update submodule on merge.