### PR TITLE
focus config window on open

### DIFF
--- a/src/config/about.swift
+++ b/src/config/about.swift
@@ -8,7 +8,7 @@ struct AboutView: View {
   }
 }
 
-class FcitxAbout: NSWindowController {
+class FcitxAbout: ConfigWindowController {
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 480, height: 300),

--- a/src/config/menu.swift
+++ b/src/config/menu.swift
@@ -76,13 +76,14 @@ class ConfigWindowController: NSWindowController, NSWindowDelegate {
         ConfigWindowController.numberOfConfigWindows += 1
       }
 
-      window.makeKeyAndOrderFront(nil)
-
       // Switch to normal activation policy so that the config windows
       // can receive key events.
       if NSApp.activationPolicy() != .regular {
         NSApp.setActivationPolicy(.regular)
       }
+
+      window.makeKeyAndOrderFront(nil)
+      NSApp.activate(ignoringOtherApps: true)
     }
   }
 


### PR DESCRIPTION
master: Input Method is frontmost but not focused. Global config is neither. About doesn't even have an icon in dock.
PR: all frontmost and focused.