### PR TITLE
in-app update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Lint
         run: |
           find macosfrontend macosnotifications webpanel src -name '*.cpp' -o -name '*.h' | xargs clang-format -Werror --dry-run -style=file:fcitx5/.clang-format
-          swift-format lint --configuration .swift-format.json -rs macosfrontend macosnotifications src
+          swift-format lint --configuration .swift-format.json -rs macosfrontend macosnotifications src assets
           for file in $(git ls-files | grep '\.swift$'); do
             if grep 'NSLog(' $file; then
               echo "Please use Logging module instead of NSLog"

--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -1,9 +1,13 @@
+add_executable(switch_im switch_im.swift)
+
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/fcitx.icns"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/Resources"
 )
 
 # Preserve execution permission
 install(PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/uninstall.sh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/update.sh"
+    "${CMAKE_CURRENT_BINARY_DIR}/switch_im"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/Resources"
 )
 

--- a/assets/switch_im.swift
+++ b/assets/switch_im.swift
@@ -1,0 +1,20 @@
+import Carbon
+
+let arguments = CommandLine.arguments
+
+if arguments.count < 2 {
+  exit(1)
+}
+
+let im = arguments[1]
+
+let conditions = NSMutableDictionary()
+conditions.setValue(im, forKey: kTISPropertyInputSourceID as String)
+if let array = TISCreateInputSourceList(conditions, true)?.takeRetainedValue()
+  as? [TISInputSource]
+{
+  for inputSource in array {
+    TISSelectInputSource(inputSource)
+    exit(0)
+  }
+}

--- a/assets/update.sh
+++ b/assets/update.sh
@@ -1,0 +1,20 @@
+#!/bin/zsh
+set -xeu
+
+user="$1"
+tar_ball="$2"
+INSTALL_DIR="/Library/Input Methods"
+APP_DIR="$INSTALL_DIR/Fcitx5.app"
+RESOURCES_DIR="$APP_DIR/Contents/Resources"
+
+rm -rf "$APP_DIR/Contents/*"
+tar xjvf "$tar_ball" -C "$INSTALL_DIR"
+rm -f "$tar_ball"
+xattr -dr com.apple.quarantine "$APP_DIR"
+codesign --force --sign - --deep "$APP_DIR"
+
+cd "$RESOURCES_DIR"
+# Switching out is necessary, otherwise it doesn't show menu
+su -m "$user" -c "./switch_im com.apple.keylayout.ABC"
+killall Fcitx5
+su -m "$user" -c "./switch_im org.fcitx.inputmethod.Fcitx5.fcitx5"

--- a/src/config/about.swift
+++ b/src/config/about.swift
@@ -184,6 +184,7 @@ struct AboutView: View {
           .sheet(
             isPresented: $viewModel.showAvailable,
             onDismiss: {
+              // Clicking "Update now" will also dismiss this sheet, and it happens before this.
               if viewModel.state == .availableSheet {
                 viewModel.state = .available
               }

--- a/src/config/about.swift
+++ b/src/config/about.swift
@@ -344,6 +344,7 @@ struct AboutView: View {
 
   func update() {
     let fileName = "Fcitx5-\(getArch()).tar.bz2"
+    mkdirP(cacheDirectory.path())
     let destinationURL = cacheDirectory.appendingPathComponent(fileName)
     if FileManager.default.fileExists(atPath: destinationURL.path()) {
       FCITX_INFO("Using cached \(fileName)")

--- a/src/config/about.swift
+++ b/src/config/about.swift
@@ -1,7 +1,9 @@
 import Carbon
+import Logging
 import SwiftUI
 
 let sourceRepo = "https://github.com/fcitx-contrib/fcitx5-macos"
+let updateLog = "/tmp/Fcitx5Update.log"
 let uninstallLog = "/tmp/Fcitx5Uninstall.log"
 
 func getDate() -> String {
@@ -45,7 +47,34 @@ func disableInputMethod() {
   }
 }
 
+struct Object: Codable {
+  let sha: String
+}
+
+struct Tag: Codable {
+  let object: Object
+}
+
+enum UpdateState {
+  case notChecked  // Clickable "Check update"
+  case checking  // Disabled "Checking"
+  case checkFailedSheet  // to notChecked
+  case upToDateSheet  // to upToDate
+  case upToDate  // Disabled "Check update", reset to notChecked on refresh
+  case availableSheet  // to available or downloading
+  case available  // Clickable "Update"
+  case downloading  // Disabled "Update"
+  case downloadFailedSheet  // to available
+  case installing  // Disabled "Update"
+  case installFailedSheet  // to available
+}
+
 struct AboutView: View {
+  // @State won't work as it doesn't update view when the value is changed in refresh().
+  @ObservedObject private var viewModel = ViewModel()
+  @State private var observer: NSKeyValueObservation? = nil
+  @State private var downloadProgress = 0.0
+
   @State private var confirmUninstall = false
   @State private var removeUserData = false
   @State private var uninstallFailed = false
@@ -92,6 +121,131 @@ struct AboutView: View {
 
       Spacer().frame(height: gapSize)
       HStack {
+        Button(
+          action: {
+            if viewModel.state == .notChecked {
+              checkUpdate()
+            } else if viewModel.state == .available {
+              update()
+            }
+          },
+          label: {
+            if viewModel.state == .notChecked || viewModel.state == .upToDate {
+              Text("Check update")
+            } else if viewModel.state == .checking || viewModel.state == .checkFailedSheet
+              || viewModel.state == .upToDateSheet || viewModel.state == .availableSheet
+            {
+              Text("Checking")
+            } else {
+              Text("Update")
+            }
+          }
+        ).buttonStyle(.borderedProminent)
+          .disabled(
+            viewModel.state == .checking || viewModel.state == .upToDate
+              || viewModel.state == .downloading || viewModel.state == .installing
+          )
+          .sheet(
+            isPresented: $viewModel.showCheckFailed,
+            onDismiss: {
+              viewModel.state = .notChecked
+            }
+          ) {
+            VStack {
+              Text("Failed to check update")
+              Button(
+                action: {
+                  viewModel.state = .notChecked
+                },
+                label: {
+                  Text("OK")
+                }
+              ).buttonStyle(.borderedProminent)
+            }.padding()
+          }
+          .sheet(
+            isPresented: $viewModel.showUpToDate,
+            onDismiss: {
+              viewModel.state = .upToDate
+            }
+          ) {
+            VStack {
+              Text("Fcitx5 is up to date")
+              Button(
+                action: {
+                  viewModel.state = .upToDate
+                },
+                label: {
+                  Text("OK")
+                }
+              ).buttonStyle(.borderedProminent)
+            }.padding()
+          }
+          .sheet(
+            isPresented: $viewModel.showAvailable,
+            onDismiss: {
+              if viewModel.state == .availableSheet {
+                viewModel.state = .available
+              }
+            }
+          ) {
+            VStack {
+              Text("Update available")
+              Button(
+                action: {
+                  update()
+                },
+                label: {
+                  Text("Update now")
+                }
+              ).buttonStyle(.borderedProminent)
+              Button(
+                action: {
+                  viewModel.state = .available
+                },
+                label: {
+                  Text("Maybe later")
+                }
+              )
+            }.padding()
+          }
+          .sheet(
+            isPresented: $viewModel.showDownloadFailed,
+            onDismiss: {
+              viewModel.state = .available
+            }
+          ) {
+            VStack {
+              Text("Download failed")
+              Button(
+                action: {
+                  viewModel.state = .available
+                },
+                label: {
+                  Text("OK")
+                }
+              ).buttonStyle(.borderedProminent)
+            }.padding()
+          }
+          .sheet(
+            isPresented: $viewModel.showInstallFailed,
+            onDismiss: {
+              viewModel.state = .available
+            }
+          ) {
+            VStack {
+              Text("Install failed")
+              Button(
+                action: {
+                  viewModel.state = .available
+                },
+                label: {
+                  Text("OK")
+                }
+              ).buttonStyle(.borderedProminent)
+            }.padding()
+          }
+
         Button(
           action: {
             confirmUninstall = true
@@ -148,6 +302,9 @@ struct AboutView: View {
           }.padding()
         }
       }
+      if viewModel.state == .downloading {
+        ProgressView(value: downloadProgress, total: 1)
+      }
     }.padding()
   }
 
@@ -160,16 +317,141 @@ struct AboutView: View {
       uninstallFailed = true
     }
   }
+
+  func checkUpdate() {
+    guard
+      let url = URL(
+        string: "https://api.github.com/repos/fcitx-contrib/fcitx5-macos/git/ref/tags/latest")
+    else {
+      return
+    }
+    viewModel.state = .checking
+    URLSession.shared.dataTask(with: url) { data, response, error in
+      if let data = data,
+        let tag = try? JSONDecoder().decode(Tag.self, from: data)
+      {
+        if tag.object.sha == commit {
+          viewModel.state = .upToDateSheet
+        } else {
+          viewModel.state = .availableSheet
+        }
+      } else {
+        viewModel.state = .checkFailedSheet
+      }
+    }.resume()
+  }
+
+  func update() {
+    let fileName = "Fcitx5-\(getArch()).tar.bz2"
+    let destinationURL = cacheDirectory.appendingPathComponent(fileName)
+    if FileManager.default.fileExists(atPath: destinationURL.path()) {
+      FCITX_INFO("Using cached \(fileName)")
+      return install(destinationURL.path())
+    }
+    viewModel.state = .downloading
+    guard let url = URL(string: "\(sourceRepo)/releases/download/latest/\(fileName)") else {
+      return
+    }
+    let task = URLSession.shared.downloadTask(with: url) { localURL, response, error in
+      observer?.invalidate()
+      if let localURL = localURL,
+        let httpResponse = response as? HTTPURLResponse,
+        httpResponse.statusCode == 200
+      {
+        do {
+          try FileManager.default.moveItem(at: localURL, to: destinationURL)
+          DispatchQueue.main.async {
+            install(destinationURL.path())
+          }
+          return
+        } catch {
+          FCITX_ERROR("Error moving file: \(error)")
+        }
+      }
+      DispatchQueue.main.async {
+        viewModel.state = .downloadFailedSheet
+      }
+    }
+    observer = task.progress.observe(\.fractionCompleted) { progress, _ in
+      downloadProgress = progress.fractionCompleted
+    }
+    task.resume()
+  }
+
+  func install(_ path: String) {
+    viewModel.state = .installing
+    let conditions = NSMutableDictionary()
+    conditions.setValue("com.apple.keylayout.ABC", forKey: kTISPropertyInputSourceID as String)
+    if let array = TISCreateInputSourceList(conditions, true)?.takeRetainedValue()
+      as? [TISInputSource]
+    {
+      for inputSource in array {
+        TISSelectInputSource(inputSource)
+      }
+    }
+    // Necessary to put it in background, otherwise sudo UI will hang if it has been canceled once.
+    DispatchQueue.global().async {
+      if !sudo("update", path, updateLog) {
+        DispatchQueue.main.async {
+          viewModel.state = .installFailedSheet
+        }
+      }
+    }
+  }
+
+  func refresh() {
+    viewModel.refresh()
+  }
+
+  private class ViewModel: ObservableObject {
+    @Published var state: UpdateState = .notChecked {
+      didSet {
+        showCheckFailed = false
+        showUpToDate = false
+        showAvailable = false
+        showDownloadFailed = false
+        showInstallFailed = false
+        if state == .checkFailedSheet {
+          showCheckFailed = true
+        } else if state == .upToDateSheet {
+          showUpToDate = true
+        } else if state == .availableSheet {
+          showAvailable = true
+        } else if state == .downloadFailedSheet {
+          showDownloadFailed = true
+        } else if state == .installFailedSheet {
+          showInstallFailed = true
+        }
+      }
+    }
+    @Published var showCheckFailed: Bool = false
+    @Published var showUpToDate: Bool = false
+    @Published var showAvailable: Bool = false
+    @Published var showDownloadFailed: Bool = false
+    @Published var showInstallFailed: Bool = false
+
+    func refresh() {
+      if state == .upToDate {
+        state = .notChecked
+      }
+    }
+  }
 }
 
-class FcitxAbout: ConfigWindowController {
+class FcitxAboutController: ConfigWindowController {
+  let view = AboutView()
+
   convenience init() {
     let window = NSWindow(
       contentRect: NSRect(x: 0, y: 0, width: 480, height: 600),
       styleMask: [.titled, .closable],
       backing: .buffered, defer: false)
-    window.contentView = NSHostingView(rootView: AboutView())
     window.center()
     self.init(window: window)
+    window.contentView = NSHostingView(rootView: view)
+  }
+
+  func refresh() {
+    view.refresh()
   }
 }

--- a/src/config/menu.swift
+++ b/src/config/menu.swift
@@ -9,8 +9,8 @@ func restartAndReconnect() {
 }
 
 extension FcitxInputController {
-  static var fcitxAbout: NSWindowController = {
-    return FcitxAbout()
+  static var fcitxAbout: FcitxAboutController = {
+    return FcitxAboutController()
   }()
   static var pluginManager: PluginManager = {
     return PluginManager()
@@ -35,6 +35,7 @@ extension FcitxInputController {
   }
 
   @objc func about(_: Any? = nil) {
+    FcitxInputController.fcitxAbout.refresh()
     FcitxInputController.fcitxAbout.showWindow(nil)
   }
 

--- a/src/config/plugin.swift
+++ b/src/config/plugin.swift
@@ -21,7 +21,7 @@ let fcitxDirectory = FileManager.default.homeDirectoryForCurrentUser
   .appendingPathComponent("Library")
   .appendingPathComponent("fcitx5")
 private let pluginDirectory = fcitxDirectory.appendingPathComponent("plugin")
-private let cacheDirectory = fcitxDirectory.appendingPathComponent("cache")
+let cacheDirectory = fcitxDirectory.appendingPathComponent("cache")
 
 struct Plugin: Identifiable, Hashable {
   let id: String


### PR DESCRIPTION
For every sheet, ESC and OK have the same effect.
Test procedure:
* Set src/config/meta.swift so that commit is the same with master, rebuild.
* Turn off network, Check update, Failed to check update.
* Turn on network, Check update, Fcitx5 is up to date. Button is disabled. Reopen about could reenable it.
* Rebuild. Check update, Maybe later, the button should be Update, and remains on reopen.
* Update, but cancel sudo password, should prompt error.
* Update with password, about window should quit, but you should be able to use the updated version seamlessly.