### PR TITLE
hack: trim label end as linux ui impl specific

### DIFF
--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -115,7 +115,14 @@ void WebPanel::update(UserInterfaceComponent component,
                     instance_
                         ->outputFilter(inputContext, list->candidate(i).text())
                         .toString());
-                labels.emplace_back(list->label(i).toString());
+                auto label = list->label(i).toString();
+                // HACK: fcitx5's Linux UI concatenates label and text and
+                // expects engine to append a ' ' to label.
+                auto length = label.length();
+                if (length && label[length - 1] == ' ') {
+                    label = label.substr(0, length - 1);
+                }
+                labels.emplace_back(label);
             }
             highlighted = list->cursorIndex();
             // }


### PR DESCRIPTION
Before:
<img width="411" alt="before" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/4a62ca6a-bd27-487f-b570-c3a02f0d2623">

<br>

After:
<img width="375" alt="after" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/2211cf1d-25f3-4af9-8d10-b55c6425ee3c">
