### PR TITLE
send capital keysym when a-z is shift-modified

### DIFF
--- a/macosfrontend/keycode.cpp
+++ b/macosfrontend/keycode.cpp
@@ -171,12 +171,17 @@ static struct {
     {OSX_VK_SHIFT_R, 54},
 };
 
-fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode,
-                                          uint16_t osxKeycode) {
+fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode, uint16_t osxKeycode,
+                                          uint32_t osxModifiers) {
     for (const auto &pair : sym_mappings) {
         if (pair.osxKeycode == osxKeycode) {
             return pair.sym;
         }
+    }
+    // send capital keysym when shift is pressed (bug #101)
+    if ((unicode >= 'a') && (unicode <= 'z') &&
+        (osxModifiers & OSX_MODIFIER_SHIFT)) {
+        unicode = unicode - 'a' + 'A';
     }
     return fcitx::Key::keySymFromUnicode(unicode);
 }

--- a/macosfrontend/keycode.cpp
+++ b/macosfrontend/keycode.cpp
@@ -178,7 +178,10 @@ fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode, uint16_t osxKeycode,
             return pair.sym;
         }
     }
-    // send capital keysym when shift is pressed (bug #101)
+    // Send capital keysym when shift is pressed (bug #101)
+    // This is for Squirrel compatibility:
+    // Squirrel recognizes Control+Shift+F and Control+Shift+0
+    // but not Control+Shift+f and Control+Shift+parenright
     if ((unicode >= 'a') && (unicode <= 'z') &&
         (osxModifiers & OSX_MODIFIER_SHIFT)) {
         unicode = unicode - 'a' + 'A';

--- a/macosfrontend/keycode.h
+++ b/macosfrontend/keycode.h
@@ -253,8 +253,8 @@
 #define OSX_MODIFIER_FUNCTION   (1 << 23)
 // clang-format on
 
-fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode,
-                                          uint16_t osxKeycode);
+fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode, uint16_t osxKeycode,
+                                          uint32_t osxModifiers);
 uint16_t osx_keycode_to_fcitx_keycode(uint16_t osxKeycode);
 fcitx::KeyStates osx_modifiers_to_fcitx_keystates(uint32_t osxModifiers);
 

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -177,7 +177,7 @@ MacosInputContext::getCursorCoordinates(bool followCursor) {
 bool process_key(ICUUID uuid, uint32_t unicode, uint32_t osxModifiers,
                  uint16_t osxKeycode, bool isRelease) noexcept {
     const fcitx::Key parsedKey{
-        osx_unicode_to_fcitx_keysym(unicode, osxKeycode),
+        osx_unicode_to_fcitx_keysym(unicode, osxKeycode, osxModifiers),
         osx_modifiers_to_fcitx_keystates(osxModifiers),
         osx_keycode_to_fcitx_keycode(osxKeycode),
     };


### PR DESCRIPTION
fixes #101

also tested with other input methods