### PR TITLE
Stabilize commit, set preedit, return handled order in main thread

### DIFF
--- a/macosfrontend/macosfrontend-public.h
+++ b/macosfrontend/macosfrontend-public.h
@@ -4,8 +4,8 @@
 #include "fcitx-public.h"
 
 // Though being UInt, 32b is enough for modifiers
-bool process_key(ICUUID uuid, uint32_t unicode, uint32_t osxModifiers,
-                 uint16_t osxKeycode, bool isRelease) noexcept;
+std::string process_key(ICUUID uuid, uint32_t unicode, uint32_t osxModifiers,
+                        uint16_t osxKeycode, bool isRelease) noexcept;
 
 ICUUID create_input_context(const char *appId, id client) noexcept;
 void destroy_input_context(ICUUID uuid) noexcept;

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -154,7 +154,6 @@ void MacosInputContext::commitStringImpl(const std::string &text) {
 void MacosInputContext::updatePreeditImpl() {
     auto preedit =
         frontend_->instance()->outputFilter(this, inputPanel().clientPreedit());
-    preeditEmpty = preedit.empty();
     state_.preedit = preedit.toString();
     state_.cursorPos = preedit.cursor();
 }
@@ -164,17 +163,9 @@ std::string MacosInputContext::getState(bool accepted) {
     j["commit"] = state_.commit;
     j["preedit"] = state_.preedit;
     j["cursorPos"] = state_.cursorPos;
+    j["dummyPreedit"] = int(state_.dummyPreedit);
     j["accepted"] = int(accepted);
     return j.dump();
-}
-
-void MacosInputContext::forcePreedit(bool show) {
-    if (preeditEmpty) {
-        // Without client preedit, Backspace bypasses IM in Terminal, every key
-        // is both processed by IM and passed to client in iTerm, so we force a
-        // dummy client preedit here.
-        // SwiftFrontend::setPreedit(client_, show ? " " : "", 0);
-    }
 }
 
 std::pair<double, double>

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -41,11 +41,13 @@ void MacosFrontend::save() {
     safeSaveAsIni(config_, ConfPath);
 }
 
-bool MacosFrontend::keyEvent(ICUUID uuid, const Key &key, bool isRelease) {
+std::string MacosFrontend::keyEvent(ICUUID uuid, const Key &key,
+                                    bool isRelease) {
     auto *ic = this->findIC(uuid);
     if (!ic) {
-        return false;
+        return "{}";
     }
+    ic->resetState();
     ic->focusIn();
     KeyEvent keyEvent(ic, key, isRelease);
     ic->keyEvent(keyEvent);
@@ -67,7 +69,7 @@ bool MacosFrontend::keyEvent(ICUUID uuid, const Key &key, bool isRelease) {
         auto timeEventPtr = timeEvent.release();
     }
 
-    return keyEvent.accepted();
+    return ic->getState(keyEvent.accepted());
 }
 
 MacosInputContext *MacosFrontend::findIC(ICUUID uuid) {
@@ -117,7 +119,9 @@ void MacosFrontend::focusIn(ICUUID uuid) {
     if (!ic)
         return;
     ic->focusIn();
-    useAppDefaultIM(ic->program());
+    auto program = ic->program();
+    FCITX_INFO() << "Focus in " << program;
+    useAppDefaultIM(program);
 }
 
 void MacosFrontend::focusOut(ICUUID uuid) {
@@ -144,14 +148,24 @@ MacosInputContext::~MacosInputContext() {
 }
 
 void MacosInputContext::commitStringImpl(const std::string &text) {
-    SwiftFrontend::commit(client_, text);
+    state_.commit += text;
 }
 
 void MacosInputContext::updatePreeditImpl() {
     auto preedit =
         frontend_->instance()->outputFilter(this, inputPanel().clientPreedit());
     preeditEmpty = preedit.empty();
-    SwiftFrontend::setPreedit(client_, preedit.toString(), preedit.cursor());
+    state_.preedit = preedit.toString();
+    state_.cursorPos = preedit.cursor();
+}
+
+std::string MacosInputContext::getState(bool accepted) {
+    nlohmann::json j;
+    j["commit"] = state_.commit;
+    j["preedit"] = state_.preedit;
+    j["cursorPos"] = state_.cursorPos;
+    j["accepted"] = int(accepted);
+    return j.dump();
 }
 
 void MacosInputContext::forcePreedit(bool show) {
@@ -159,7 +173,7 @@ void MacosInputContext::forcePreedit(bool show) {
         // Without client preedit, Backspace bypasses IM in Terminal, every key
         // is both processed by IM and passed to client in iTerm, so we force a
         // dummy client preedit here.
-        SwiftFrontend::setPreedit(client_, show ? " " : "", 0);
+        // SwiftFrontend::setPreedit(client_, show ? " " : "", 0);
     }
 }
 
@@ -174,8 +188,8 @@ MacosInputContext::getCursorCoordinates(bool followCursor) {
 
 } // namespace fcitx
 
-bool process_key(ICUUID uuid, uint32_t unicode, uint32_t osxModifiers,
-                 uint16_t osxKeycode, bool isRelease) noexcept {
+std::string process_key(ICUUID uuid, uint32_t unicode, uint32_t osxModifiers,
+                        uint16_t osxKeycode, bool isRelease) noexcept {
     const fcitx::Key parsedKey{
         osx_unicode_to_fcitx_keysym(unicode, osxKeycode, osxModifiers),
         osx_modifiers_to_fcitx_keystates(osxModifiers),

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -90,6 +90,7 @@ struct InputContextState {
     std::string commit;
     std::string preedit;
     int cursorPos;
+    bool dummyPreedit;
 };
 
 class MacosInputContext : public InputContext {
@@ -104,7 +105,6 @@ public:
     void deleteSurroundingTextImpl(int offset, unsigned int size) override {}
     void forwardKeyImpl(const ForwardKeyEvent &key) override {}
     void updatePreeditImpl() override;
-    void forcePreedit(bool show);
 
     std::pair<double, double> getCursorCoordinates(bool followCursor);
     id client() { return client_; }
@@ -112,7 +112,11 @@ public:
     void resetState() {
         state_.commit.clear();
         state_.preedit.clear();
-        state_.cursorPos = -1;
+        state_.cursorPos = 0;
+        state_.dummyPreedit = false;
+    }
+    void setDummyPreedit(bool dummyPreedit) {
+        state_.dummyPreedit = dummyPreedit;
     }
     std::string getState(bool accepted);
 
@@ -120,7 +124,6 @@ private:
     MacosFrontend *frontend_;
     id client_;
     InputContextState state_;
-    bool preeditEmpty = true; // the fake preedit doesn't count here
 };
 
 class MacosFrontendFactory : public AddonFactory {

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -65,7 +65,7 @@ public:
 
     ICUUID createInputContext(const std::string &appId, id client);
     void destroyInputContext(ICUUID);
-    bool keyEvent(ICUUID, const Key &key, bool isRelease);
+    std::string keyEvent(ICUUID, const Key &key, bool isRelease);
     void focusIn(ICUUID);
     void focusOut(ICUUID);
 
@@ -86,6 +86,12 @@ private:
     void useAppDefaultIM(const std::string &appId);
 };
 
+struct InputContextState {
+    std::string commit;
+    std::string preedit;
+    int cursorPos;
+};
+
 class MacosInputContext : public InputContext {
 public:
     MacosInputContext(MacosFrontend *frontend,
@@ -103,9 +109,17 @@ public:
     std::pair<double, double> getCursorCoordinates(bool followCursor);
     id client() { return client_; }
 
+    void resetState() {
+        state_.commit.clear();
+        state_.preedit.clear();
+        state_.cursorPos = -1;
+    }
+    std::string getState(bool accepted);
+
 private:
     MacosFrontend *frontend_;
     id client_;
+    InputContextState state_;
     bool preeditEmpty = true; // the fake preedit doesn't count here
 };
 

--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -3,8 +3,7 @@ import InputMethodKit
 private var u16pos = 0
 private var currentPreedit = ""
 
-public func commit(_ clientPtr: UnsafeMutableRawPointer, _ string: String) {
-  let client: AnyObject = Unmanaged.fromOpaque(clientPtr).takeUnretainedValue()
+public func commit(_ client: Any!, _ string: String) {
   if let client = client as? IMKTextInput {
     client.insertText(string, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
   }
@@ -12,9 +11,7 @@ public func commit(_ clientPtr: UnsafeMutableRawPointer, _ string: String) {
 
 // Executed in fcitx thread, so before process_key returns, no UI update
 // will happen. That means we can't get coordinates in this function.
-public func setPreedit(_ clientPtr: UnsafeMutableRawPointer, _ preedit: String, _ caretPosUtf8: Int)
-{
-  let client: AnyObject = Unmanaged.fromOpaque(clientPtr).takeUnretainedValue()
+public func setPreedit(_ client: Any!, _ preedit: String, _ caretPosUtf8: Int) {
   if let client = client as? IMKTextInput {
     currentPreedit = preedit
     // The caretPos argument is specified in UTF-8 bytes.

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -50,6 +50,7 @@ class FcitxInputController: IMKInputController {
         let json = try JSON(data: data)
         let commit = try String?.decode(json: json["commit"]) ?? ""
         let preedit = try String?.decode(json: json["preedit"]) ?? ""
+        // Bool?.decode doesn't work so use int for all bool fields.
         let cursorPos = try Int?.decode(json: json["cursorPos"]) ?? -1
         let dummyPreedit = (try Int?.decode(json: json["dummyPreedit"]) ?? 0) == 1
         let accepted = (try Int?.decode(json: json["accepted"]) ?? 0) == 1

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -51,11 +51,17 @@ class FcitxInputController: IMKInputController {
         let commit = try String?.decode(json: json["commit"]) ?? ""
         let preedit = try String?.decode(json: json["preedit"]) ?? ""
         let cursorPos = try Int?.decode(json: json["cursorPos"]) ?? -1
+        let dummyPreedit = (try Int?.decode(json: json["dummyPreedit"]) ?? 0) == 1
         let accepted = (try Int?.decode(json: json["accepted"]) ?? 0) == 1
         if !commit.isEmpty {
           SwiftFrontend.commit(client, commit)
         }
-        if cursorPos >= 0 {
+        // Without client preedit, Backspace bypasses IM in Terminal, every key
+        // is both processed by IM and passed to client in iTerm, so we force a
+        // dummy client preedit here.
+        if preedit.isEmpty && dummyPreedit {
+          SwiftFrontend.setPreedit(client, " ", 0)
+        } else {
           SwiftFrontend.setPreedit(client, preedit, cursorPos)
         }
         return accepted

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -155,8 +155,9 @@ void WebPanel::update(UserInterfaceComponent component,
         window_->set_layout(layout);
         updatePanelShowFlags(!candidates.empty(), PanelShowFlag::HasCandidates);
         if (auto macosIC = dynamic_cast<MacosInputContext *>(inputContext)) {
-            macosIC->forcePreedit((panelShow_ & PanelShowFlag::HasPreedit) |
-                                  (panelShow_ & PanelShowFlag::HasCandidates));
+            macosIC->setDummyPreedit(
+                (panelShow_ & PanelShowFlag::HasPreedit) |
+                (panelShow_ & PanelShowFlag::HasCandidates));
         }
         showAsync(panelShow_);
         break;


### PR DESCRIPTION
Someone reports 顶功 may randomly fail after deployment with [星猫键道](https://github.com/hugh7007/xmjd6-rere).
A possible reason is
<img src="https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/c5b110e2-cbc4-4d45-b8c9-590867a6d1ff" width="400px" />

A possible solution is
<img src="https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/9723a70a-ed93-433c-bb4b-c94a861148a6" width="400px" />

It's proved that iTerm2 requires set preedit before return handled.
This may also fix candidate window jumpsing to origin when librime-predict is enabled in telegram.
Since dummy preedit implementation is changed, also need to test scenarios of #69.