### PR TITLE
replace GitHub API with meta.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,19 @@ jobs:
       - name: Check validity
         run: ./check-validity.sh
 
+      - name: Generate meta.json
+        if: ${{ matrix.os == 'macos-14' }}
+        run: |
+          echo "{\"object\": {\"sha\": \"$(git rev-parse HEAD)\"}}" > meta.json
+
+      - name: Upload meta.json
+        if: ${{ matrix.os == 'macos-14' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: meta.json
+          path: |
+            meta.json
+
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
@@ -113,3 +126,4 @@ jobs:
           files: |
             Fcitx5-x86_64.tar.bz2
             Fcitx5-arm64.tar.bz2
+            meta.json

--- a/src/config/about.swift
+++ b/src/config/about.swift
@@ -321,8 +321,10 @@ struct AboutView: View {
 
   func checkUpdate() {
     guard
+      // https://api.github.com/repos/fcitx-contrib/fcitx5-macos/git/ref/tags/latest
+      // GitHub API may be blocked in China and is unstable in general.
       let url = URL(
-        string: "https://api.github.com/repos/fcitx-contrib/fcitx5-macos/git/ref/tags/latest")
+        string: "https://github.com/fcitx-contrib/fcitx5-macos/releases/download/latest/meta.json")
     else {
       return
     }


### PR DESCRIPTION
Generate a meta.json that has the same structure of the unstable GitHub API. The accessibility of meta.json and artifact are the same so there should be no more to optimize.
For test, I've manually uploaded a meta.json to release. You should be able to downgrade to current master on this branch, and if you do `git reset --soft master` and rebuild to force master's commit sha to be used, you should see Fcitx5 is up to date.