### PR TITLE
try fix segfault on client (async UAF?)

### DIFF
--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -174,10 +174,9 @@ std::string MacosInputContext::getState(bool accepted) {
 void MacosInputContext::commitAndSetPreeditAsync() {
     auto state = state_;
     resetState();
-    dispatch_async(dispatch_get_main_queue(), ^void() {
-      SwiftFrontend::commitAndSetPreedit(client_, state.commit, state.preedit,
-                                         state.cursorPos, state.dummyPreedit);
-    });
+    SwiftFrontend::commitAndSetPreeditAsync(client_, state.commit,
+                                            state.preedit, state.cursorPos,
+                                            state.dummyPreedit);
 }
 
 std::pair<double, double>

--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -27,7 +27,7 @@ private func setPreedit(_ client: IMKTextInput, _ preedit: String, _ caretPosUtf
   )
 }
 
-public func commitAndSetPreeditImpl(
+public func commitAndSetPreeditSync(
   _ client: IMKTextInput, _ commit: String, _ preedit: String, _ cursorPos: Int,
   _ dummyPreedit: Bool
 ) {
@@ -44,7 +44,7 @@ public func commitAndSetPreeditImpl(
   }
 }
 
-public func commitAndSetPreedit(
+public func commitAndSetPreeditAsync(
   _ clientPtr: UnsafeMutableRawPointer, _ commit: String, _ preedit: String, _ cursorPos: Int,
   _ dummyPreedit: Bool
 ) {
@@ -52,7 +52,9 @@ public func commitAndSetPreedit(
   guard let client = client as? IMKTextInput else {
     return
   }
-  commitAndSetPreeditImpl(client, commit, preedit, cursorPos, dummyPreedit)
+  DispatchQueue.main.async {
+    commitAndSetPreeditSync(client, commit, preedit, cursorPos, dummyPreedit)
+  }
 }
 
 public func getCursorCoordinates(

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -57,7 +57,7 @@ class FcitxInputController: IMKInputController {
         let cursorPos = try Int?.decode(json: json["cursorPos"]) ?? -1
         let dummyPreedit = (try Int?.decode(json: json["dummyPreedit"]) ?? 0) == 1
         let accepted = (try Int?.decode(json: json["accepted"]) ?? 0) == 1
-        commitAndSetPreeditImpl(client, commit, preedit, cursorPos, dummyPreedit)
+        commitAndSetPreeditSync(client, commit, preedit, cursorPos, dummyPreedit)
         return accepted
       }
     } catch {


### PR DESCRIPTION
I guess the problem is that IC may be destroyed before the code deferred to main thread is executed. So I make the swift function async instead of the C++ function.
While I have no guarantee that it can avoid the crash, I do believe we won't see the same stacktrace again.
```
Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x00005741e5894870
Exception Codes:       0x0000000000000001, 0x00005741e5894870

Termination Reason:    Namespace SIGNAL, Code 11 Segmentation fault: 11
Terminating Process:   exc handler [742]

VM Region Info: 0x5741e5894870 is not in any region.  Bytes after previous region: 95927650568305  Bytes before following region: 3914568480656
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      VM_ALLOCATE (reserved)      2f8000000-300000000    [128.0M] rw-/rw- SM=NUL  reserved VM address space (unallocated)
--->  GAP OF 0x5ace54000000 BYTES
      JS JIT generated code    5ad154000000-5ad154001000 [    4K] ---/rwx SM=NUL  

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libswiftCore.dylib            	    0x7ff815e777f9 swift_unknownObjectRetain_n + 41
1   Fcitx5                        	       0x105d3d949 commitAndSetPreedit(_:_:_:_:_:) + 57
2   Fcitx5                        	       0x105db954c invocation function for block in fcitx::MacosInputContext::commitAndSetPreeditAsync() + 140
3   libdispatch.dylib             	    0x7ff8052e4ac6 _dispatch_call_block_and_release + 12
4   libdispatch.dylib             	    0x7ff8052e5dbc _dispatch_client_callout + 8
5   libdispatch.dylib             	    0x7ff8052f21df _dispatch_main_queue_drain + 984
6   libdispatch.dylib             	    0x7ff8052f1df9 _dispatch_main_queue_callback_4CF + 31
7   CoreFoundation                	    0x7ff8055a3866 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
8   CoreFoundation                	    0x7ff805562a95 __CFRunLoopRun + 2459
9   CoreFoundation                	    0x7ff805561b32 CFRunLoopRunSpecific + 557
10  HIToolbox                     	    0x7ff80ff73829 RunCurrentEventLoopInMode + 292
11  HIToolbox                     	    0x7ff80ff73636 ReceiveNextEventCommon + 665
12  HIToolbox                     	    0x7ff80ff73381 _BlockUntilNextEventMatchingListInModeWithFilter + 66
13  AppKit                        	    0x7ff808bc9be5 _DPSNextEvent + 880
14  AppKit                        	    0x7ff8094d9fe9 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1273
15  AppKit                        	    0x7ff808bbb005 -[NSApplication run] + 603
16  AppKit                        	    0x7ff808b8eff1 NSApplicationMain + 816
17  Fcitx5                        	       0x105c9ddfc main + 28
18  dyld                          	    0x7ff8050fb366 start + 1942
```
