### PR TITLE
use weak_ptr to avoid async uaf

### DIFF
--- a/webpanel/webpanel.h
+++ b/webpanel/webpanel.h
@@ -256,7 +256,7 @@ public:
 
 private:
     Instance *instance_;
-    std::unique_ptr<candidate_window::CandidateWindow> window_;
+    std::shared_ptr<candidate_window::CandidateWindow> window_;
 
     static const inline std::string ConfPath = "conf/webpanel.conf";
     WebPanelConfig config_;


### PR DESCRIPTION
Reproduce:
* Checkout 83e214aa3f34f9be1a52aaa343fe3aac5ad798ff
* Import a .dict file in Pinyin's dict manager.
* Crash on https://github.com/fcitx-contrib/fcitx5-webview/blob/7a93ac2955c32f5df0b2b547f83cd32ec5e3374e/include/webview_candidate_window.hpp#L61 (the call is `updateInputPanel("", "", "")`)

Merge this branch to see no error.

Ref: https://chat.openai.com/share/4ecb4853-547e-4de9-9d88-11a1d0a021f7

Please update submodule on merge.