### PR TITLE
fix xkeyboard-config and iso-codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,6 @@ jobs:
         run: |
           brew install \
             nlohmann-json \
-            xkeyboardconfig \
-            iso-codes \
             extra-cmake-modules \
             ninja
           ./install-deps.sh ${{ matrix.arch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,11 @@ set(CMAKE_INSTALL_PREFIX "${APP_INSTALL_PATH}/Fcitx5.app/Contents")
 # Reproducible
 set(CMAKE_INSTALL_LIBDATADIR "${CMAKE_INSTALL_PREFIX}/lib")
 
-# Override iso-codes paths
+# Override iso-codes paths and xkb default rules file
 set(ISOCODES_ISO3166_JSON "${CMAKE_INSTALL_PREFIX}/share/iso-codes/json/iso_3166-1.json")
 set(ISOCODES_ISO639_JSON "${CMAKE_INSTALL_PREFIX}/share/iso-codes/json/iso_639-3.json")
-mark_as_advanced(FORCE ISOCODES_ISO639_JSON ISOCODES_ISO3166_JSON)
+set(XKEYBOARDCONFIG_XKBBASE "${CMAKE_INSTALL_PREFIX}/share/X11/xkb")
+set(XKEYBOARDCONFIG_DATADIR "${CMAKE_INSTALL_PREFIX}/share")
 
 add_subdirectory(fcitx5)
 add_subdirectory(deps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 set(CMAKE_OSX_DEPLOYMENT_TARGET 13)
 add_definitions(-target "${CMAKE_OSX_ARCHITECTURES}-apple-macos${CMAKE_OSX_DEPLOYMENT_TARGET}")
 
-# Need HOMEBREW_PATH for iso-codes and xkeyboardconfig
+# Need HOMEBREW_PATH for nlohmann-json
 if(CMAKE_OSX_ARCHITECTURES STREQUAL arm64)
     set(HOMEBREW_PATH "/opt/homebrew")
 else()
@@ -26,7 +26,7 @@ endif()
 
 set(PREBUILT_INSTALL_PATH "/tmp/fcitx5")
 
-set(ENV{PKG_CONFIG_PATH} "${PREBUILT_INSTALL_PATH}/lib/pkgconfig:${HOMEBREW_PATH}/share/pkgconfig")
+set(ENV{PKG_CONFIG_PATH} "${PREBUILT_INSTALL_PATH}/lib/pkgconfig:${PREBUILT_INSTALL_PATH}/share/pkgconfig")
 
 # For dependencies not to be find via pkg-config
 set(LibIntl_DIR "${PREBUILT_INSTALL_PATH}/lib/cmake")
@@ -56,6 +56,12 @@ set(APP_INSTALL_PATH "/Library/Input Methods")
 set(CMAKE_INSTALL_PREFIX "${APP_INSTALL_PATH}/Fcitx5.app/Contents")
 # Reproducible
 set(CMAKE_INSTALL_LIBDATADIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+# Override iso-codes paths
+set(ISOCODES_ISO3166_JSON "${CMAKE_INSTALL_PREFIX}/share/iso-codes/json/iso_3166-1.json")
+set(ISOCODES_ISO639_JSON "${CMAKE_INSTALL_PREFIX}/share/iso-codes/json/iso_639-3.json")
+mark_as_advanced(FORCE ISOCODES_ISO639_JSON ISOCODES_ISO3166_JSON)
+
 add_subdirectory(fcitx5)
 add_subdirectory(deps)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to install node, then
 
 ```sh
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-brew install cmake ninja extra-cmake-modules gettext iso-codes xkeyboardconfig nlohmann-json
+brew install cmake ninja extra-cmake-modules gettext nlohmann-json
 ./install-deps.sh
 npm i -g pnpm
 pnpm --prefix=fcitx5-webview i

--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -31,6 +31,14 @@ install(DIRECTORY "${PREBUILT_INSTALL_PATH}/share/icons"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/share"
 )
 
+install(DIRECTORY "${PREBUILT_INSTALL_PATH}/share/iso-codes"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/share"
+)
+
+install(DIRECTORY "${PREBUILT_INSTALL_PATH}/share/X11"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/share"
+)
+
 #
 # Swift i18n through Localizable.strings
 # Use 'GenerateStrings' to update .strings files.

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -27,7 +27,3 @@ for dep in "${deps[@]}"; do
   [[ -f cache/$file ]] || wget -P cache https://github.com/fcitx-contrib/fcitx5-macos-prebuilder/releases/download/latest/$file
   tar xjvf cache/$file -C $INSTALL_PREFIX
 done
-
-# HACK: make xkb rules discoverable
-mkdir -p "/Library/Input Methods/Fcitx5.app/Contents/share"
-cp -a /tmp/fcitx5/share/X11 "/Library/Input Methods/Fcitx5.app/Contents/share"

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -27,3 +27,7 @@ for dep in "${deps[@]}"; do
   [[ -f cache/$file ]] || wget -P cache https://github.com/fcitx-contrib/fcitx5-macos-prebuilder/releases/download/latest/$file
   tar xjvf cache/$file -C $INSTALL_PREFIX
 done
+
+# HACK: make xkb rules discoverable
+mkdir -p "/Library/Input Methods/Fcitx5.app/Contents/share"
+cp -a /tmp/fcitx5/share/X11 "/Library/Input Methods/Fcitx5.app/Contents/share"

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -18,6 +18,8 @@ deps=(
   json-c
   libuv
   libxkbcommon
+  iso-codes
+  xkeyboard-config
 )
 
 for dep in "${deps[@]}"; do


### PR DESCRIPTION
there will be no more errors that mention '/tmp/fcitx5' in the logs.

should be able to use other keyboard types without issues.