### PR TITLE
support vertical writing modes

### DIFF
--- a/assets/po/zh_CN.po
+++ b/assets/po/zh_CN.po
@@ -32,242 +32,246 @@ msgstr "模拟按键释放延迟毫秒数"
 msgid "Hidden Notifications"
 msgstr "隐藏通知"
 
-#: webpanel/webpanel.h:37
+#: webpanel/webpanel.h:40
 msgid "Follow cursor"
 msgstr "跟随光标"
 
-#: webpanel/webpanel.h:39
+#: webpanel/webpanel.h:42
 msgid "Theme"
 msgstr "主题"
 
-#: webpanel/webpanel.h:44 webpanel/webpanel.h:88
+#: webpanel/webpanel.h:47 webpanel/webpanel.h:91
 msgid "Override default"
 msgstr "覆盖默认值"
 
-#: webpanel/webpanel.h:45 webpanel/webpanel.h:91
+#: webpanel/webpanel.h:48 webpanel/webpanel.h:94
 msgid "Highlight color"
 msgstr "高亮颜色"
 
-#: webpanel/webpanel.h:48 webpanel/webpanel.h:94
+#: webpanel/webpanel.h:51 webpanel/webpanel.h:97
 msgid "Highlight color on hover"
 msgstr "悬停时高亮颜色"
 
-#: webpanel/webpanel.h:51 webpanel/webpanel.h:97
+#: webpanel/webpanel.h:54 webpanel/webpanel.h:100
 msgid "Highlight text color"
 msgstr "高亮文本颜色"
 
-#: webpanel/webpanel.h:54 webpanel/webpanel.h:100
+#: webpanel/webpanel.h:57 webpanel/webpanel.h:103
 msgid "Highlight text color on press"
 msgstr "按下时高亮文本颜色"
 
-#: webpanel/webpanel.h:57 webpanel/webpanel.h:103
+#: webpanel/webpanel.h:60 webpanel/webpanel.h:106
 msgid "Highlight label color"
 msgstr "高亮标签颜色"
 
-#: webpanel/webpanel.h:60 webpanel/webpanel.h:106
+#: webpanel/webpanel.h:63 webpanel/webpanel.h:109
 msgid "Highlight comment color"
 msgstr "高亮注释颜色"
 
-#: webpanel/webpanel.h:63 webpanel/webpanel.h:109
+#: webpanel/webpanel.h:66 webpanel/webpanel.h:112
 msgid "Highlight mark color"
 msgstr "高亮标记颜色"
 
-#: webpanel/webpanel.h:65 webpanel/webpanel.h:111
+#: webpanel/webpanel.h:68 webpanel/webpanel.h:114
 msgid "Panel color"
 msgstr "面板颜色"
 
-#: webpanel/webpanel.h:67 webpanel/webpanel.h:113
+#: webpanel/webpanel.h:70 webpanel/webpanel.h:116
 msgid "Text color"
 msgstr "文本颜色"
 
-#: webpanel/webpanel.h:69 webpanel/webpanel.h:115
+#: webpanel/webpanel.h:72 webpanel/webpanel.h:118
 msgid "Label color"
 msgstr "标签颜色"
 
-#: webpanel/webpanel.h:71 webpanel/webpanel.h:117
+#: webpanel/webpanel.h:74 webpanel/webpanel.h:120
 msgid "Comment color"
 msgstr "注释颜色"
 
-#: webpanel/webpanel.h:74 webpanel/webpanel.h:120
+#: webpanel/webpanel.h:77 webpanel/webpanel.h:123
 msgid "Paging button color"
 msgstr "翻页按钮颜色"
 
-#: webpanel/webpanel.h:77 webpanel/webpanel.h:123
+#: webpanel/webpanel.h:80 webpanel/webpanel.h:126
 msgid "Disabled paging button color"
 msgstr "禁用的翻页按钮颜色"
 
-#: webpanel/webpanel.h:79 webpanel/webpanel.h:125
+#: webpanel/webpanel.h:82 webpanel/webpanel.h:128
 msgid "Preedit color"
 msgstr "预编辑颜色"
 
-#: webpanel/webpanel.h:81 webpanel/webpanel.h:127
+#: webpanel/webpanel.h:84 webpanel/webpanel.h:130
 msgid "Border color"
 msgstr "边框颜色"
 
-#: webpanel/webpanel.h:83 webpanel/webpanel.h:129
+#: webpanel/webpanel.h:86 webpanel/webpanel.h:132
 msgid "Divider color"
 msgstr "分隔线颜色"
 
-#: webpanel/webpanel.h:90
+#: webpanel/webpanel.h:93
 msgid "Same with light mode"
 msgstr "与浅色模式相同"
 
-#: webpanel/webpanel.h:134
+#: webpanel/webpanel.h:138
 msgid "Layout"
 msgstr "布局"
 
-#: webpanel/webpanel.h:137
+#: webpanel/webpanel.h:140
+msgid "Writing mode"
+msgstr "书写模式"
+
+#: webpanel/webpanel.h:143
 msgid "Show paging buttons"
 msgstr "显示翻页按钮"
 
-#: webpanel/webpanel.h:142
+#: webpanel/webpanel.h:147
 msgid "Image URL"
 msgstr "图片 URL"
 
-#: webpanel/webpanel.h:143
+#: webpanel/webpanel.h:148
 msgid "Blur"
 msgstr "模糊"
 
-#: webpanel/webpanel.h:145
+#: webpanel/webpanel.h:150
 msgid "Radius of blur (px)"
 msgstr "模糊半径（px）"
 
-#: webpanel/webpanel.h:147
+#: webpanel/webpanel.h:152
 msgid "Shadow"
 msgstr "阴影"
 
-#: webpanel/webpanel.h:155
+#: webpanel/webpanel.h:160
 msgid "Text font family"
 msgstr "文本字体族"
 
-#: webpanel/webpanel.h:157
+#: webpanel/webpanel.h:162
 msgid "Text font size"
 msgstr "文本字号"
 
-#: webpanel/webpanel.h:159
+#: webpanel/webpanel.h:164
 msgid "Label font family"
 msgstr "标签字体族"
 
-#: webpanel/webpanel.h:161
+#: webpanel/webpanel.h:166
 msgid "Label font size"
 msgstr "标签字号"
 
-#: webpanel/webpanel.h:163
+#: webpanel/webpanel.h:168
 msgid "Comment font family"
 msgstr "注释字体族"
 
-#: webpanel/webpanel.h:165
+#: webpanel/webpanel.h:170
 msgid "Comment font size"
 msgstr "注释字号"
 
-#: webpanel/webpanel.h:168
+#: webpanel/webpanel.h:173
 msgid "Preedit font family"
 msgstr "预编辑字体族"
 
-#: webpanel/webpanel.h:170
+#: webpanel/webpanel.h:175
 msgid "Preedit font size"
 msgstr "预编辑字号"
 
-#: webpanel/webpanel.h:172
+#: webpanel/webpanel.h:177
 msgid "User font dir"
 msgstr "用户字体目录"
 
-#: webpanel/webpanel.h:173
+#: webpanel/webpanel.h:178
 msgid "System font dir"
 msgstr "系统字体目录"
 
-#: webpanel/webpanel.h:177
+#: webpanel/webpanel.h:182
 msgid "Style"
 msgstr "样式"
 
-#: webpanel/webpanel.h:179
+#: webpanel/webpanel.h:184
 msgid "Text"
 msgstr "文本"
 
-#: webpanel/webpanel.h:183
+#: webpanel/webpanel.h:188
 msgid "Mark style"
 msgstr "标记样式"
 
-#: webpanel/webpanel.h:185
+#: webpanel/webpanel.h:190
 msgid "Mark text"
 msgstr "标记文本"
 
-#: webpanel/webpanel.h:187
+#: webpanel/webpanel.h:192
 msgid "Hover behavior"
 msgstr "悬停行为"
 
-#: webpanel/webpanel.h:192
+#: webpanel/webpanel.h:197
 msgid "Border width (px)"
 msgstr "边框宽度（px）"
 
-#: webpanel/webpanel.h:195
+#: webpanel/webpanel.h:200
 msgid "Border radius (px)"
 msgstr "边框半径（px）"
 
-#: webpanel/webpanel.h:196
+#: webpanel/webpanel.h:201
 msgid "Margin (px)"
 msgstr "外边距（px）"
 
-#: webpanel/webpanel.h:199
+#: webpanel/webpanel.h:204
 msgid "Highlight radius (px)"
 msgstr "高亮半径（px）"
 
-#: webpanel/webpanel.h:202
+#: webpanel/webpanel.h:207
 msgid "Top padding (px)"
 msgstr "顶填充（px）"
 
-#: webpanel/webpanel.h:204
+#: webpanel/webpanel.h:209
 msgid "Right padding (px)"
 msgstr "右填充（px）"
 
-#: webpanel/webpanel.h:206
+#: webpanel/webpanel.h:211
 msgid "Bottom padding (px)"
 msgstr "底填充（px）"
 
-#: webpanel/webpanel.h:209
+#: webpanel/webpanel.h:214
 msgid "Left padding (px)"
 msgstr "左填充（px）"
 
-#: webpanel/webpanel.h:211
+#: webpanel/webpanel.h:216
 msgid "Gap between label, text and comment (px)"
 msgstr "标签、文本、注释间隔（px）"
 
-#: webpanel/webpanel.h:214
+#: webpanel/webpanel.h:219
 msgid "Horizontal divider width (px)"
 msgstr "水平分隔线宽度（px）"
 
-#: webpanel/webpanel.h:218
+#: webpanel/webpanel.h:223
 msgid "Basic"
 msgstr "基础"
 
-#: webpanel/webpanel.h:219
+#: webpanel/webpanel.h:224
 msgid "Light mode"
 msgstr "浅色模式"
 
-#: webpanel/webpanel.h:220
+#: webpanel/webpanel.h:225
 msgid "Dark mode"
 msgstr "深色模式"
 
-#: webpanel/webpanel.h:221
+#: webpanel/webpanel.h:226
 msgid "Typography"
 msgstr "版式"
 
-#: webpanel/webpanel.h:222
+#: webpanel/webpanel.h:227
 msgid "Background"
 msgstr "背景"
 
-#: webpanel/webpanel.h:223
+#: webpanel/webpanel.h:228
 msgid "Font"
 msgstr "字体"
 
-#: webpanel/webpanel.h:224
+#: webpanel/webpanel.h:229
 msgid "Cursor"
 msgstr "光标"
 
-#: webpanel/webpanel.h:225
+#: webpanel/webpanel.h:230
 msgid "Highlight"
 msgstr "高亮"
 
-#: webpanel/webpanel.h:226
+#: webpanel/webpanel.h:231
 msgid "Size"
 msgstr "尺寸"

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -173,6 +173,7 @@ void WebPanel::update(UserInterfaceComponent component,
         window_->set_paging_buttons(pageable, hasPrev, hasNext);
         window_->set_candidates(candidates, highlighted);
         window_->set_layout(layout);
+        window_->set_writing_mode(config_.typography->writingMode.value());
         updatePanelShowFlags(!candidates.empty(), PanelShowFlag::HasCandidates);
         if (auto macosIC = dynamic_cast<MacosInputContext *>(inputContext)) {
             macosIC->setDummyPreedit(

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -171,9 +171,9 @@ void WebPanel::update(UserInterfaceComponent component,
             }
         }
         window_->set_paging_buttons(pageable, hasPrev, hasNext);
+        window_->set_writing_mode(config_.typography->writingMode.value());
         window_->set_candidates(candidates, highlighted);
         window_->set_layout(layout);
-        window_->set_writing_mode(config_.typography->writingMode.value());
         updatePanelShowFlags(!candidates.empty(), PanelShowFlag::HasCandidates);
         if (auto macosIC = dynamic_cast<MacosInputContext *>(inputContext)) {
             macosIC->setDummyPreedit(

--- a/webpanel/webpanel.h
+++ b/webpanel/webpanel.h
@@ -16,6 +16,9 @@
 namespace candidate_window {
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(theme_t, N_("System"), N_("Light"), N_("Dark"))
 FCITX_CONFIG_ENUM_NAME_WITH_I18N(layout_t, N_("Horizontal"), N_("Vertical"))
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(writing_mode_t, N_("Horizontal top-bottom"),
+                                 N_("Vertical right-left"),
+                                 N_("Vertical left-right"))
 } // namespace candidate_window
 
 enum class CursorStyle { Blink, Static, Text };
@@ -129,13 +132,15 @@ FCITX_CONFIGURATION(
     Option<Color> dividerColor{this, "DividerColor", _("Divider color"),
                                Color(255, 255, 255, 255)};);
 
-FCITX_CONFIGURATION(TypographyConfig,
-                    Option<candidate_window::layout_t> layout{
-                        this, "Layout", _("Layout"),
-                        candidate_window::layout_t::horizontal};
-                    Option<bool> showPagingButtons{this, "ShowPagingButtons",
-                                                   _("Show paging buttons"),
-                                                   false};);
+FCITX_CONFIGURATION(
+    TypographyConfig,
+    Option<candidate_window::layout_t> layout{
+        this, "Layout", _("Layout"), candidate_window::layout_t::horizontal};
+    Option<candidate_window::writing_mode_t> writingMode{
+        this, "WritingMode", _("Writing mode"),
+        candidate_window::writing_mode_t::horizontal_tb};
+    Option<bool> showPagingButtons{this, "ShowPagingButtons",
+                                   _("Show paging buttons"), false};);
 
 FCITX_CONFIGURATION(BackgroundConfig,
                     Option<std::string> imageUrl{this, "ImageUrl",


### PR DESCRIPTION
<img width="305" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/2d3a6b73-8332-49ec-890a-576194ce1e9d">

Known issues:
* Some emojis are rotated and some not. A WebKit issue that I'm not going to hack.
* Horizontal layout + Vertical writing mode may lead to wrong multi-character candidate's layout that is corrected on drag. Use it as-is and it's not worth investigation.

Please update submodule on merge.