### PR TITLE
integrate AlertToast

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "fcitx5-beast"]
 	path = fcitx5-beast
 	url = https://github.com/fcitx-contrib/fcitx5-beast
+[submodule "deps/AlertToast"]
+	path = deps/AlertToast
+	url = https://github.com/fcitx-contrib/AlertToast

--- a/README.md
+++ b/README.md
@@ -109,5 +109,6 @@ cd assets/po && msgmerge -U <locale>.po base.pot
 * [squirrel](https://github.com/rime/squirrel): GPL-3.0-only
 * [swift-cmake-examples](https://github.com/apple/swift-cmake-examples): Apache-2.0
 * [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON): MIT
+* [AlertToast](https://github.com/elai950/AlertToast): MIT
 * [pugixml](https://github.com/zeux/pugixml): MIT
 * [webview](https://github.com/webview/webview): MIT

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(SwiftyJSON STATIC "${CMAKE_CURRENT_SOURCE_DIR}/SwiftyJSON/Source/SwiftyJSON/SwiftyJSON.swift")
 set_target_properties(SwiftyJSON PROPERTIES Swift_MODULE_NAME SwiftyJSON)
 target_include_directories(SwiftyJSON PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/SwiftyJSON/Source/SwiftyJSON")
+
+file(GLOB ALERT_TOAST_FILES CONFIGURE_DEPENDS AlertToast/src/*.swift)
+add_library(AlertToast STATIC ${ALERT_TOAST_FILES})
+set_target_properties(AlertToast PROPERTIES Swift_MODULE_NAME AlertToast)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ target_include_directories(Fcitx5Objs PUBLIC
 )
 target_link_libraries(Fcitx5Objs
     "-Xlinker -rpath -Xlinker '${CMAKE_INSTALL_PREFIX}/lib'"
+    AlertToast
     SwiftyJSON
     SwiftFrontend
     SwiftNotify

--- a/src/config/about.swift
+++ b/src/config/about.swift
@@ -62,7 +62,6 @@ enum UpdateState {
   case availableSheet  // to available or downloading
   case available  // Clickable "Update"
   case downloading  // Disabled "Update"
-  case downloadFailedSheet  // to available
   case installing  // Disabled "Update"
   case installFailedSheet  // to available
 }
@@ -74,6 +73,7 @@ struct AboutView: View {
 
   @State private var showUpToDate = false
   @State private var showCheckFailed = false
+  @State private var showDownloadFailed = false
   @State private var confirmUninstall = false
   @State private var removeUserData = false
   @State private var uninstallFailed = false
@@ -174,24 +174,6 @@ struct AboutView: View {
             }.padding()
           }
           .sheet(
-            isPresented: $viewModel.showDownloadFailed,
-            onDismiss: {
-              viewModel.state = .available
-            }
-          ) {
-            VStack {
-              Text("Download failed")
-              Button(
-                action: {
-                  viewModel.state = .available
-                },
-                label: {
-                  Text("OK")
-                }
-              ).buttonStyle(.borderedProminent)
-            }.padding()
-          }
-          .sheet(
             isPresented: $viewModel.showInstallFailed,
             onDismiss: {
               viewModel.state = .available
@@ -280,6 +262,11 @@ struct AboutView: View {
           displayMode: .hud, type: .error(Color.red),
           title: NSLocalizedString("Failed to check update", comment: ""))
       }
+      .toast(isPresenting: $showDownloadFailed) {
+        AlertToast(
+          displayMode: .hud, type: .error(Color.red),
+          title: NSLocalizedString("Download failed", comment: ""))
+      }
   }
 
   func uninstall() {
@@ -329,7 +316,8 @@ struct AboutView: View {
           if result {
             install()
           } else {
-            viewModel.state = .downloadFailedSheet
+            viewModel.state = .available
+            showDownloadFailed = true
           }
         },
         onProgress: { progress in
@@ -368,19 +356,15 @@ struct AboutView: View {
     @Published var state: UpdateState = .notChecked {
       didSet {
         showAvailable = false
-        showDownloadFailed = false
         showInstallFailed = false
         if state == .availableSheet {
           showAvailable = true
-        } else if state == .downloadFailedSheet {
-          showDownloadFailed = true
         } else if state == .installFailedSheet {
           showInstallFailed = true
         }
       }
     }
     @Published var showAvailable: Bool = false
-    @Published var showDownloadFailed: Bool = false
     @Published var showInstallFailed: Bool = false
 
     func refresh() {

--- a/src/config/plugin.swift
+++ b/src/config/plugin.swift
@@ -1,3 +1,4 @@
+import AlertToast
 import Fcitx
 import Logging
 import SwiftUI
@@ -308,16 +309,7 @@ struct PluginView: View {
             Text("Check update")
           }.buttonStyle(.borderedProminent)
             .disabled(processing || pluginVM.upToDate)
-            .sheet(isPresented: $showUpToDate) {
-              VStack {
-                Text("All plugins are up to date")
-                Button {
-                  showUpToDate = false
-                } label: {
-                  Text("OK")
-                }.buttonStyle(.borderedProminent)
-              }.padding()
-            }.sheet(isPresented: $showUpdateAvailable) {
+            .sheet(isPresented: $showUpdateAvailable) {
               VStack {
                 Text("Update available")
 
@@ -391,6 +383,12 @@ struct PluginView: View {
             }
           ).buttonStyle(.borderedProminent)
         }.padding()
+      }
+      .toast(isPresenting: $showUpToDate) {
+        AlertToast(
+          displayMode: .hud,
+          type: .complete(Color.green),
+          title: NSLocalizedString("All plugins are up to date", comment: ""))
       }
   }
 }


### PR DESCRIPTION
<img width="275" src="https://github.com/fcitx-contrib/fcitx5-macos/assets/26783539/5ffc2152-7fdb-40cb-b9a8-ea26b7bf3e33">

5 less sheets that are ugly and require unnecessary user interaction.
This PR only handles replacement because I want to see a negative LoC change. Will add spin/success/failure to other scenarios.