### PR TITLE
fix list option parse

### DIFF
--- a/src/config/optionmodels.swift
+++ b/src/config/optionmodels.swift
@@ -396,10 +396,14 @@ class ListOption<T: Option & EmptyConstructible>: Option, ObservableObject {
 
   static func decode(json: JSON) throws -> Self {
     let defaultOptions = try [T.Storage].decode(json: json["DefaultValue"]).map {
-      return try T.decode(json: ["DefaultValue": $0, "Value": $0])
+      return try T.decode(json: [
+        "DefaultValue": $0.encodeValueJSON(), "Value": $0.encodeValueJSON(),
+      ])
     }
     let options = try [T.Storage].decode(json: json["Value"]).map {
-      try T.decode(json: ["DefaultValue": $0, "Value": $0])
+      return try T.decode(json: [
+        "DefaultValue": $0.encodeValueJSON(), "Value": $0.encodeValueJSON(),
+      ])
     }
     return Self(
       defaultValue: defaultOptions,


### PR DESCRIPTION
This is a bug since day 1. The purpose of this code is to convert

```
ListOption([ val1, val2, ... ])
````

into

```
[Option(val1), Option(val2), ...]
```

The decode in the map expects JSON values, but previously `$0` is decoded value, not json value.

The old buggy code works for simple values, like integers and arrays, but not on complex custom data types, which will become `unknown` values hidden inside the outer json value, and will explode later.