### PR TITLE
copy html to clipboard

### DIFF
--- a/assets/po/zh_CN.po
+++ b/assets/po/zh_CN.po
@@ -32,246 +32,254 @@ msgstr "模拟按键释放延迟毫秒数"
 msgid "Hidden Notifications"
 msgstr "隐藏通知"
 
-#: webpanel/webpanel.h:40
+#: webpanel/webpanel.h:39
 msgid "Follow cursor"
 msgstr "跟随光标"
 
-#: webpanel/webpanel.h:42
+#: webpanel/webpanel.h:41
 msgid "Theme"
 msgstr "主题"
 
-#: webpanel/webpanel.h:47 webpanel/webpanel.h:91
+#: webpanel/webpanel.h:46 webpanel/webpanel.h:90
 msgid "Override default"
 msgstr "覆盖默认值"
 
-#: webpanel/webpanel.h:48 webpanel/webpanel.h:94
+#: webpanel/webpanel.h:47 webpanel/webpanel.h:93
 msgid "Highlight color"
 msgstr "高亮颜色"
 
-#: webpanel/webpanel.h:51 webpanel/webpanel.h:97
+#: webpanel/webpanel.h:50 webpanel/webpanel.h:96
 msgid "Highlight color on hover"
 msgstr "悬停时高亮颜色"
 
-#: webpanel/webpanel.h:54 webpanel/webpanel.h:100
+#: webpanel/webpanel.h:53 webpanel/webpanel.h:99
 msgid "Highlight text color"
 msgstr "高亮文本颜色"
 
-#: webpanel/webpanel.h:57 webpanel/webpanel.h:103
+#: webpanel/webpanel.h:56 webpanel/webpanel.h:102
 msgid "Highlight text color on press"
 msgstr "按下时高亮文本颜色"
 
-#: webpanel/webpanel.h:60 webpanel/webpanel.h:106
+#: webpanel/webpanel.h:59 webpanel/webpanel.h:105
 msgid "Highlight label color"
 msgstr "高亮标签颜色"
 
-#: webpanel/webpanel.h:63 webpanel/webpanel.h:109
+#: webpanel/webpanel.h:62 webpanel/webpanel.h:108
 msgid "Highlight comment color"
 msgstr "高亮注释颜色"
 
-#: webpanel/webpanel.h:66 webpanel/webpanel.h:112
+#: webpanel/webpanel.h:65 webpanel/webpanel.h:111
 msgid "Highlight mark color"
 msgstr "高亮标记颜色"
 
-#: webpanel/webpanel.h:68 webpanel/webpanel.h:114
+#: webpanel/webpanel.h:67 webpanel/webpanel.h:113
 msgid "Panel color"
 msgstr "面板颜色"
 
-#: webpanel/webpanel.h:70 webpanel/webpanel.h:116
+#: webpanel/webpanel.h:69 webpanel/webpanel.h:115
 msgid "Text color"
 msgstr "文本颜色"
 
-#: webpanel/webpanel.h:72 webpanel/webpanel.h:118
+#: webpanel/webpanel.h:71 webpanel/webpanel.h:117
 msgid "Label color"
 msgstr "标签颜色"
 
-#: webpanel/webpanel.h:74 webpanel/webpanel.h:120
+#: webpanel/webpanel.h:73 webpanel/webpanel.h:119
 msgid "Comment color"
 msgstr "注释颜色"
 
-#: webpanel/webpanel.h:77 webpanel/webpanel.h:123
+#: webpanel/webpanel.h:76 webpanel/webpanel.h:122
 msgid "Paging button color"
 msgstr "翻页按钮颜色"
 
-#: webpanel/webpanel.h:80 webpanel/webpanel.h:126
+#: webpanel/webpanel.h:79 webpanel/webpanel.h:125
 msgid "Disabled paging button color"
 msgstr "禁用的翻页按钮颜色"
 
-#: webpanel/webpanel.h:82 webpanel/webpanel.h:128
+#: webpanel/webpanel.h:81 webpanel/webpanel.h:127
 msgid "Preedit color"
 msgstr "预编辑颜色"
 
-#: webpanel/webpanel.h:84 webpanel/webpanel.h:130
+#: webpanel/webpanel.h:83 webpanel/webpanel.h:129
 msgid "Border color"
 msgstr "边框颜色"
 
-#: webpanel/webpanel.h:86 webpanel/webpanel.h:132
+#: webpanel/webpanel.h:85 webpanel/webpanel.h:131
 msgid "Divider color"
 msgstr "分隔线颜色"
 
-#: webpanel/webpanel.h:93
+#: webpanel/webpanel.h:92
 msgid "Same with light mode"
 msgstr "与浅色模式相同"
 
-#: webpanel/webpanel.h:138
+#: webpanel/webpanel.h:137
 msgid "Layout"
 msgstr "布局"
 
-#: webpanel/webpanel.h:140
+#: webpanel/webpanel.h:139
 msgid "Writing mode"
 msgstr "书写模式"
 
-#: webpanel/webpanel.h:143
+#: webpanel/webpanel.h:142
 msgid "Show paging buttons"
 msgstr "显示翻页按钮"
 
-#: webpanel/webpanel.h:147
+#: webpanel/webpanel.h:146
 msgid "Image URL"
 msgstr "图片 URL"
 
-#: webpanel/webpanel.h:148
+#: webpanel/webpanel.h:147
 msgid "Blur"
 msgstr "模糊"
 
-#: webpanel/webpanel.h:150
+#: webpanel/webpanel.h:149
 msgid "Radius of blur (px)"
 msgstr "模糊半径（px）"
 
-#: webpanel/webpanel.h:152
+#: webpanel/webpanel.h:151
 msgid "Shadow"
 msgstr "阴影"
 
-#: webpanel/webpanel.h:160
+#: webpanel/webpanel.h:159
 msgid "Text font family"
 msgstr "文本字体族"
 
-#: webpanel/webpanel.h:162
+#: webpanel/webpanel.h:161
 msgid "Text font size"
 msgstr "文本字号"
 
-#: webpanel/webpanel.h:164
+#: webpanel/webpanel.h:163
 msgid "Label font family"
 msgstr "标签字体族"
 
-#: webpanel/webpanel.h:166
+#: webpanel/webpanel.h:165
 msgid "Label font size"
 msgstr "标签字号"
 
-#: webpanel/webpanel.h:168
+#: webpanel/webpanel.h:167
 msgid "Comment font family"
 msgstr "注释字体族"
 
-#: webpanel/webpanel.h:170
+#: webpanel/webpanel.h:169
 msgid "Comment font size"
 msgstr "注释字号"
 
-#: webpanel/webpanel.h:173
+#: webpanel/webpanel.h:172
 msgid "Preedit font family"
 msgstr "预编辑字体族"
 
-#: webpanel/webpanel.h:175
+#: webpanel/webpanel.h:174
 msgid "Preedit font size"
 msgstr "预编辑字号"
 
-#: webpanel/webpanel.h:177
+#: webpanel/webpanel.h:176
 msgid "User font dir"
 msgstr "用户字体目录"
 
-#: webpanel/webpanel.h:178
+#: webpanel/webpanel.h:177
 msgid "System font dir"
 msgstr "系统字体目录"
 
-#: webpanel/webpanel.h:182
+#: webpanel/webpanel.h:181
 msgid "Style"
 msgstr "样式"
 
-#: webpanel/webpanel.h:184
+#: webpanel/webpanel.h:183
 msgid "Text"
 msgstr "文本"
 
-#: webpanel/webpanel.h:188
+#: webpanel/webpanel.h:187
 msgid "Mark style"
 msgstr "标记样式"
 
-#: webpanel/webpanel.h:190
+#: webpanel/webpanel.h:189
 msgid "Mark text"
 msgstr "标记文本"
 
-#: webpanel/webpanel.h:192
+#: webpanel/webpanel.h:191
 msgid "Hover behavior"
 msgstr "悬停行为"
 
-#: webpanel/webpanel.h:197
+#: webpanel/webpanel.h:196
 msgid "Border width (px)"
 msgstr "边框宽度（px）"
 
-#: webpanel/webpanel.h:200
+#: webpanel/webpanel.h:199
 msgid "Border radius (px)"
 msgstr "边框半径（px）"
 
-#: webpanel/webpanel.h:201
+#: webpanel/webpanel.h:200
 msgid "Margin (px)"
 msgstr "外边距（px）"
 
-#: webpanel/webpanel.h:204
+#: webpanel/webpanel.h:203
 msgid "Highlight radius (px)"
 msgstr "高亮半径（px）"
 
-#: webpanel/webpanel.h:207
+#: webpanel/webpanel.h:206
 msgid "Top padding (px)"
 msgstr "顶填充（px）"
 
-#: webpanel/webpanel.h:209
+#: webpanel/webpanel.h:208
 msgid "Right padding (px)"
 msgstr "右填充（px）"
 
-#: webpanel/webpanel.h:211
+#: webpanel/webpanel.h:210
 msgid "Bottom padding (px)"
 msgstr "底填充（px）"
 
-#: webpanel/webpanel.h:214
+#: webpanel/webpanel.h:213
 msgid "Left padding (px)"
 msgstr "左填充（px）"
 
-#: webpanel/webpanel.h:216
+#: webpanel/webpanel.h:215
 msgid "Gap between label, text and comment (px)"
 msgstr "标签、文本、注释间隔（px）"
 
-#: webpanel/webpanel.h:219
+#: webpanel/webpanel.h:218
 msgid "Horizontal divider width (px)"
 msgstr "水平分隔线宽度（px）"
 
-#: webpanel/webpanel.h:223
+#: webpanel/webpanel.h:222
+msgid "Copy HTML"
+msgstr "复制 HTML"
+
+#: webpanel/webpanel.h:225
 msgid "Basic"
 msgstr "基础"
 
-#: webpanel/webpanel.h:224
+#: webpanel/webpanel.h:226
 msgid "Light mode"
 msgstr "浅色模式"
 
-#: webpanel/webpanel.h:225
+#: webpanel/webpanel.h:227
 msgid "Dark mode"
 msgstr "深色模式"
 
-#: webpanel/webpanel.h:226
+#: webpanel/webpanel.h:228
 msgid "Typography"
 msgstr "版式"
 
-#: webpanel/webpanel.h:227
+#: webpanel/webpanel.h:229
 msgid "Background"
 msgstr "背景"
 
-#: webpanel/webpanel.h:228
+#: webpanel/webpanel.h:230
 msgid "Font"
 msgstr "字体"
 
-#: webpanel/webpanel.h:229
+#: webpanel/webpanel.h:231
 msgid "Cursor"
 msgstr "光标"
 
-#: webpanel/webpanel.h:230
+#: webpanel/webpanel.h:232
 msgid "Highlight"
 msgstr "高亮"
 
-#: webpanel/webpanel.h:231
+#: webpanel/webpanel.h:233
 msgid "Size"
 msgstr "尺寸"
+
+#: webpanel/webpanel.h:234
+msgid "Advanced"
+msgstr "高级"

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -4,6 +4,7 @@
 #include "../macosfrontend/macosfrontend.h"
 #include "config/config.h"
 #include "webpanel.h"
+#include "webview_candidate_window.hpp"
 
 namespace fcitx {
 
@@ -60,6 +61,21 @@ WebPanel::WebPanel(Instance *instance)
         });
     });
     window_->set_init_callback([this]() { reloadConfig(); });
+    eventHandler_ = instance_->watchEvent(
+        EventType::InputContextKeyEvent, EventWatcherPhase::Default,
+        [this](Event &event) {
+            auto &keyEvent = static_cast<KeyEvent &>(event);
+            if (keyEvent.isRelease()) {
+                return;
+            }
+            auto *ic = keyEvent.inputContext();
+            if (keyEvent.key().checkKeyList(*config_.advanced->copyHtml)) {
+                static_cast<candidate_window::WebviewCandidateWindow *>(
+                    window_.get())
+                    ->copy_html();
+                keyEvent.filterAndAccept();
+            }
+        });
 }
 
 void WebPanel::updateConfig() {

--- a/webpanel/webpanel.h
+++ b/webpanel/webpanel.h
@@ -9,7 +9,6 @@
 #include <fcitx/instance.h>
 
 #include "candidate_window.hpp"
-#include "webview_candidate_window.hpp"
 
 #define BORDER_WIDTH_MAX 10
 
@@ -219,6 +218,9 @@ FCITX_CONFIGURATION(
         this, "HorizontalDividerWidth", _("Horizontal divider width (px)"), 1,
         IntConstrain(0, BORDER_WIDTH_MAX)};);
 
+FCITX_CONFIGURATION(Advanced, Option<KeyList> copyHtml{
+                                  this, "CopyHtml", _("Copy HTML"), {}};);
+
 FCITX_CONFIGURATION(
     WebPanelConfig, Option<BasicConfig> basic{this, "Basic", _("Basic")};
     Option<LightModeConfig> lightMode{this, "LightMode", _("Light mode")};
@@ -228,10 +230,11 @@ FCITX_CONFIGURATION(
     Option<FontConfig> font{this, "Font", _("Font")};
     Option<CursorConfig> cursor{this, "Cursor", _("Cursor")};
     Option<HighlightConfig> highlight{this, "Highlight", _("Highlight")};
-    Option<Size> size{this, "Size", _("Size")};);
+    Option<Size> size{this, "Size", _("Size")};
+    Option<Advanced> advanced{this, "Advanced", _("Advanced")};);
 
 enum class PanelShowFlag : int;
-using PanelShowFlags = fcitx::Flags<PanelShowFlag>;
+using PanelShowFlags = Flags<PanelShowFlag>;
 
 class WebPanel final : public UserInterface {
 public:
@@ -260,6 +263,7 @@ private:
 
     static const inline std::string ConfPath = "conf/webpanel.conf";
     WebPanelConfig config_;
+    std::unique_ptr<HandlerTableEntry<EventHandler>> eventHandler_;
 
     void showAsync(bool show);
     PanelShowFlags panelShow_;


### PR DESCRIPTION
A shortcut with no default for develop/customize purpose since real-time inspect is disabled by default and (when enabled) cumbersome to use.