### PR TITLE
fix using Shift to select results in clearing selected text

### DIFF
--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -39,8 +39,8 @@ public func commitAndSetPreeditSync(
   // is both processed by IM and passed to client in iTerm, so we force a
   // dummy client preedit here.
   // Some apps also need it to get accurate cursor position to place candidate window.
-  // But when user selects some text using Shift, we don't want the dummy
-  // preedit resulted from IM switch clear all the selected text.
+  // But when there is selected text, we don't want the dummy preedit to clear all of
+  // them. An example is using Shift+click to select but IM switch happens.
   if preedit.isEmpty && dummyPreedit && client.selectedRange().length == 0 {
     setPreedit(client, " ", 0)
   } else {

--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -38,7 +38,10 @@ public func commitAndSetPreeditSync(
   // Without client preedit, Backspace bypasses IM in Terminal, every key
   // is both processed by IM and passed to client in iTerm, so we force a
   // dummy client preedit here.
-  if preedit.isEmpty && dummyPreedit {
+  // Some apps also need it to get accurate cursor position to place candidate window.
+  // But when user selects some text using Shift, we don't want the dummy
+  // preedit resulted from IM switch clear all the selected text.
+  if preedit.isEmpty && dummyPreedit && client.selectedRange().length == 0 {
     setPreedit(client, " ", 0)
   } else {
     setPreedit(client, preedit, cursorPos)


### PR DESCRIPTION
Tested in VSCode. Shift+click to select won't clear selected text any more.