### PR TITLE
clipboard: remove tracking parameters

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "deps/AlertToast"]
 	path = deps/AlertToast
 	url = https://github.com/fcitx-contrib/AlertToast
+[submodule "deps/url-filter"]
+	path = deps/url-filter
+	url = https://github.com/fcitx-contrib/url-filter

--- a/assets/po/zh_CN.po
+++ b/assets/po/zh_CN.po
@@ -33,6 +33,10 @@ msgid "Monitor Pasteboard"
 msgstr "监视剪贴板"
 
 #: macosfrontend/macosfrontend.h:53
+msgid "Remove tracking parameters"
+msgstr "清除追踪参数"
+
+#: macosfrontend/macosfrontend.h:56
 msgid "Poll Pasteboard interval (s)"
 msgstr "轮询剪贴板的间隔（秒）"
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -5,3 +5,5 @@ target_include_directories(SwiftyJSON PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Swifty
 file(GLOB ALERT_TOAST_FILES CONFIGURE_DEPENDS AlertToast/src/*.swift)
 add_library(AlertToast STATIC ${ALERT_TOAST_FILES})
 set_target_properties(AlertToast PROPERTIES Swift_MODULE_NAME AlertToast)
+
+add_subdirectory(url-filter)

--- a/macosfrontend/CMakeLists.txt
+++ b/macosfrontend/CMakeLists.txt
@@ -12,7 +12,7 @@ _swift_generate_cxx_header(
 
 add_library(macosfrontend STATIC macosfrontend.cpp pasteboard.mm keycode.cpp)
 add_dependencies(macosfrontend SwiftFrontend)
-target_link_libraries(macosfrontend Fcitx5::Core)
+target_link_libraries(macosfrontend Fcitx5::Core url-filter)
 target_include_directories(macosfrontend PUBLIC
     "${CMAKE_CURRENT_BINARY_DIR}/include"
     "${CMAKE_SOURCE_DIR}/src"

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -16,6 +16,7 @@
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputpanel.h>
 
+#include "../deps/url-filter/src/url-filter.hpp"
 #include "../fcitx5/src/modules/clipboard/clipboard_public.h"
 
 namespace fcitx {
@@ -39,6 +40,9 @@ void MacosFrontend::pollPasteboard() {
                     instance_->addonManager().addon("clipboard", true)) {
                 bool isPassword = false;
                 std::string str = getPasteboardString(&isPassword);
+                if (*config_.removeTrackingParameters) {
+                    str = url_filter::filterTrackingParameters(str);
+                }
                 if (!str.empty()) {
                     clipboard->call<IClipboard::setClipboardV2>("", str,
                                                                 isPassword);

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -49,6 +49,9 @@ FCITX_CONFIGURATION(
         IntConstrain(10, 1500)};
     Option<bool> monitorPasteboard{this, "MonitorPasteboard",
                                    _("Monitor Pasteboard"), false};
+    Option<bool> removeTrackingParameters{this, "RemoveTrackingParameters",
+                                          _("Remove tracking parameters"),
+                                          true};
     Option<int, IntConstrain> pollPasteboardInterval{
         this, "PollPasteboardInterval", _("Poll Pasteboard interval (s)"), 2,
         IntConstrain(1, 60)};);


### PR DESCRIPTION
Test:

https://www.google.com/search?q=tracking+parameters&sca_esv=2d68b74fb50c3936&ei=diOHZtyjKtLcptQP9O2GkAg&ved=0ahUKEwjctofnuI6HAxVSrokEHfS2AYIQ4dUDCBE&uact=5&oq=tracking+parameters&gs_lp=Egxnd3Mtd2l6LXNlcnAiE3RyYWNraW5nIHBhcmFtZXRlcnMyBRAAGIAEMgUQABiABDIFEAAYgAQyBRAAGIAEMggQABgWGB4YDzIIEAAYFhgeGA8yBhAAGBYYHjIGEAAYFhgeMgYQABgWGB4yBhAAGBYYHkjcSlCEAVjLSXAFeACQAQCYAXWgAYgEqgEDNS4xuAEDyAEA-AEC-AEBmAIJoAKOA8ICChAAGLADGNYEGEfCAgsQABiABBiRAhiKBcICCBAAGIAEGLEDwgINEAAYgAQYsQMYQxiKBcICBBAAGAOYAwCIBgGQBgOSBwM4LjGgB4UZ&sclient=gws-wiz-serp

should become

https://www.google.com/search?q=tracking+parameters&sclient=gws-wiz-serp