### PR TITLE
fix: don't set dummy preedit when switching IM for LibreOffice

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "fcitx5"]
 	path = fcitx5
-	url = https://github.com/fcitx/fcitx5
+	url = https://github.com/fcitx-contrib/fcitx5
 [submodule "fcitx5-webview"]
 	path = fcitx5-webview
 	url = https://github.com/fcitx-contrib/fcitx5-webview

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -360,7 +360,10 @@ void WebPanel::updateInputPanel(const Text &preedit, const Text &auxUp,
 
 void WebPanel::updateClient(InputContext *ic) {
     if (auto macosIC = dynamic_cast<MacosInputContext *>(ic)) {
-        macosIC->setDummyPreedit(bool(panelShow_));
+        // Don't set dummy preedit when switching IM. It will clear current cell
+        // in LibreOffice.
+        macosIC->setDummyPreedit(bool(panelShow_) &&
+                                 !macosIC->inputPanel().transient());
         if (!macosIC->isSyncEvent) {
             macosIC->commitAndSetPreeditAsync();
         }


### PR DESCRIPTION
Tested:
* Terminal: ; and Return can input ascii semicolon.
* Terminal: ESC can close an empty clipboard.
* LibreOffice: Shift won't clear current cell.

Please approve and wait for https://github.com/fcitx/fcitx5/pull/1085.