### PR TITLE
Define tunnel variables for bypassing fcitx limitations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB CONFIG_UI_FILES CONFIGURE_DEPENDS config/*.swift)
 
 add_library(Fcitx5Objs STATIC
     fcitx.cpp
+    tunnel.cpp
     config/config.cpp
     controller.swift
     ${CONFIG_UI_FILES}

--- a/src/controller.swift
+++ b/src/controller.swift
@@ -73,7 +73,7 @@ class FcitxInputController: IMKInputController {
   }
 
   override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
-    guard let event = event, let _ = sender as? IMKTextInput else {
+    guard let event = event, sender as? IMKTextInput != nil else {
       return false
     }
 

--- a/src/fcitx-public.h
+++ b/src/fcitx-public.h
@@ -44,4 +44,7 @@ std::string getAddons() noexcept;
 std::string getActions() noexcept;
 void activateActionById(int id) noexcept;
 
+// Tunnel variables
+#include "tunnel.h"
+
 #endif

--- a/src/tunnel.cpp
+++ b/src/tunnel.cpp
@@ -1,0 +1,5 @@
+#include "tunnel.h"
+
+bool f5m_is_linear_layout = false;
+bool f5m_is_vertical_rl = false;
+bool f5m_is_vertical_lr = false;

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern bool f5m_is_linear_layout;
+extern bool f5m_is_vertical_lr;
+extern bool f5m_is_vertical_rl;

--- a/webpanel/CMakeLists.txt
+++ b/webpanel/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(webpanel STATIC webpanel.cpp)
+add_library(webpanel STATIC webpanel.cpp tunnel.cpp)
 target_link_libraries(webpanel Fcitx5::Core)
 target_include_directories(webpanel PRIVATE "${PROJECT_SOURCE_DIR}/src")
 

--- a/webpanel/tunnel.cpp
+++ b/webpanel/tunnel.cpp
@@ -1,0 +1,4 @@
+// Weak definitions for tunnel variables used in webpanel.
+__attribute__((weak)) bool f5m_is_linear_layout = false;
+__attribute__((weak)) bool f5m_is_vertical_rl = false;
+__attribute__((weak)) bool f5m_is_vertical_lr = false;

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -332,11 +332,14 @@ void WebPanel::update(UserInterfaceComponent component,
         std::vector<candidate_window::Candidate> candidates;
         int size = 0;
         candidate_window::layout_t layout = config_.typography->layout.value();
-        f5m_is_linear_layout = (layout == candidate_window::layout_t::horizontal);
+        f5m_is_linear_layout =
+            (layout == candidate_window::layout_t::horizontal);
         candidate_window::writing_mode_t writingMode =
             config_.typography->writingMode.value();
-        f5m_is_vertical_rl = (writingMode == candidate_window::writing_mode_t::vertical_rl);
-        f5m_is_vertical_lr = (writingMode == candidate_window::writing_mode_t::vertical_lr);
+        f5m_is_vertical_rl =
+            (writingMode == candidate_window::writing_mode_t::vertical_rl);
+        f5m_is_vertical_lr =
+            (writingMode == candidate_window::writing_mode_t::vertical_lr);
         if (const auto &list = inputPanel.candidateList()) {
             switch (list->layoutHint()) {
             case CandidateLayoutHint::Vertical:

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -332,8 +332,11 @@ void WebPanel::update(UserInterfaceComponent component,
         std::vector<candidate_window::Candidate> candidates;
         int size = 0;
         candidate_window::layout_t layout = config_.typography->layout.value();
+        f5m_is_linear_layout = (layout == candidate_window::layout_t::horizontal);
         candidate_window::writing_mode_t writingMode =
             config_.typography->writingMode.value();
+        f5m_is_vertical_rl = (writingMode == candidate_window::writing_mode_t::vertical_rl);
+        f5m_is_vertical_lr = (writingMode == candidate_window::writing_mode_t::vertical_lr);
         if (const auto &list = inputPanel.candidateList()) {
             switch (list->layoutHint()) {
             case CandidateLayoutHint::Vertical:


### PR DESCRIPTION
Pass UI settings directly from f5m to librime. The approach here is to define some variables in tunnel.cpp, and the dynlib loader will automatically resolve undefined symbols to the definitions in the main program. However, we have to pass some linker flags to silence linker complaints. I don't expect the mechanism to be used in the future, except for hacks like this.

## How to test

1. Build and install the new f5m main program
2. Build and install the new librime (https://github.com/fcitx-contrib/fcitx5-macos-prebuilder/pull/44)
3. Build and install the new fcitx5-rime (https://github.com/fcitx-contrib/fcitx5-macos-plugins/pull/48)
4. Launch the new f5m

After this change, the new f5-rime plugin (shipped by f5m) will require the latest main program to function, or it won't be loaded (with an error message similar to 'undefined symbol' in Fcitx5.log).

Please merge prebuilder first and then merge the plugin to make sure the plugin is linked with the patched librime.