### PR TITLE
respect engine's switch behavior on focus out

### DIFF
--- a/macosfrontend/macosfrontend-public.h
+++ b/macosfrontend/macosfrontend-public.h
@@ -18,4 +18,4 @@ uint16_t fcitx_string_to_osx_keycode(const char *) noexcept;
 ICUUID create_input_context(const char *appId, id client) noexcept;
 void destroy_input_context(ICUUID uuid) noexcept;
 void focus_in(ICUUID uuid) noexcept;
-void focus_out(ICUUID uuid) noexcept;
+std::string focus_out(ICUUID uuid) noexcept;

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -75,7 +75,7 @@ public:
     void destroyInputContext(ICUUID);
     std::string keyEvent(ICUUID, const Key &key, bool isRelease);
     void focusIn(ICUUID);
-    void focusOut(ICUUID);
+    std::string focusOut(ICUUID);
 
 private:
     Instance *instance_;


### PR DESCRIPTION
Fixes #204

I enabled CapsLock to switch to ABC. At first I thought this is a chinese-addons issue as rime clears preedit. Turns out that rime clears because it recognizes CapsLock. And if using Ctrl+Space then every engine leaves a dead client preedit.
fcitx5 executes engine's deactivate method when switching IM internally, which is good enough on Linux.

The commit and clear preedit have to be executed synchronously as next cycle f5m will lose the ability to do anything on client. Dummy preedit also needs explicit suppression.