### PR TITLE
mitigate vscode terminal input Chinese punctuations

### DIFF
--- a/keycode/keycode.cpp
+++ b/keycode/keycode.cpp
@@ -299,6 +299,8 @@ static struct {
     {NSEventModifierFlagCommand, fcitx::KeyState::Super},
 };
 
+bool pinyinKeyboard = false;
+
 fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode,
                                           uint32_t osxModifiers,
                                           uint16_t osxKeycode) {
@@ -328,7 +330,22 @@ fcitx::KeySym osx_unicode_to_fcitx_keysym(uint32_t unicode,
     // but not Control+Shift+f and Control+Shift+parenright
     else if ((unicode >= 'a') && (unicode <= 'z') &&
              (osxModifiers & NSEventModifierFlagShift)) {
-        unicode = unicode - 'a' + 'A';
+        unicode += 'A' - 'a';
+    }
+    // If com.apple.keylayout.PinyinKeyboard is used, we need to map Chinese
+    // punctuations back to ASCII so that engines can handle them properly, e.g.
+    // Rime when typing pinyin followed by comma.
+    else if (pinyinKeyboard &&
+             (osxModifiers & ~NSEventModifierFlagShift) == 0) {
+        for (int i = 26; i < sizeof(char_mappings) / sizeof(char_mappings[0]);
+             i++) {
+            if (char_mappings[i].osxKeycode == osxKeycode) {
+                unicode = (osxModifiers & NSEventModifierFlagShift)
+                              ? char_mappings[i].shiftedAsciiChar
+                              : char_mappings[i].asciiChar;
+                break;
+            }
+        }
     }
     return fcitx::Key::keySymFromUnicode(unicode);
 }

--- a/keycode/keycode.h
+++ b/keycode/keycode.h
@@ -57,3 +57,5 @@ uint16_t fcitx_keysym_to_osx_function_key(fcitx::KeySym);
 
 uint16_t fcitx_keysym_to_osx_keycode(fcitx::KeySym);
 uint32_t fcitx_keystates_to_osx_modifiers(fcitx::KeyStates ks);
+
+extern bool pinyinKeyboard;

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -464,7 +464,7 @@ std::string get_current_group_layout() noexcept {
                     ;
             }
         }
-        pinyinKeyboard = groupLayout == "PinyinKeyboard";
+        ::pinyinKeyboard = groupLayout == "PinyinKeyboard";
 
         return groupLayout;
     });

--- a/macosfrontend/macosfrontend.cpp
+++ b/macosfrontend/macosfrontend.cpp
@@ -15,6 +15,7 @@
 #include <fcitx/addonmanager.h>
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputmethodengine.h>
+#include <fcitx/inputmethodentry.h>
 #include <fcitx/inputmethodmanager.h>
 #include <fcitx/inputpanel.h>
 #include <nlohmann/json.hpp>
@@ -23,6 +24,15 @@
 #include "../fcitx5/src/modules/clipboard/clipboard_public.h"
 
 namespace fcitx {
+
+bool chinesePunctuation = false;
+bool rimePunctuation = false;
+
+void overrideKeyboardLayoutAsync() {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      SwiftFrontend::overrideKeyboardLayout();
+    });
+}
 
 MacosFrontend::MacosFrontend(Instance *instance)
     : instance_(instance),
@@ -33,15 +43,11 @@ MacosFrontend::MacosFrontend(Instance *instance)
         [this](Event &event) { updateStatusItemText(); }));
     // For switching from VSCode to Terminal, otherwise the first key press
     // triggers text update.
-    eventHandlers_.emplace_back(instance_->watchEvent(
-        EventType::InputContextInputMethodActivated, EventWatcherPhase::Default,
-        [this](Event &event) { updateStatusItemText(); }));
     eventHandlers_.emplace_back(
-        instance_->watchEvent(EventType::InputMethodGroupChanged,
+        instance_->watchEvent(EventType::InputContextInputMethodActivated,
                               EventWatcherPhase::Default, [this](Event &event) {
-                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                    SwiftFrontend::overrideKeyboardLayout();
-                                  });
+                                  updateStatusItemText();
+                                  overrideKeyboardLayoutAsync();
                               }));
     reloadConfig();
 }
@@ -434,10 +440,32 @@ void focus_out(ICUUID uuid) noexcept {
 }
 
 std::string get_current_group_layout() noexcept {
-    return with_fcitx([=](Fcitx &fcitx) {
-        return fcitx.instance()
-            ->inputMethodManager()
-            .currentGroup()
-            .defaultLayout();
+    return with_fcitx([=](Fcitx &fcitx) -> std::string {
+        auto &group = fcitx.instance()->inputMethodManager().currentGroup();
+        auto groupLayout = group.defaultLayout();
+
+        auto *ic = fcitx.instance()->mostRecentInputContext();
+        auto *entry = ic ? fcitx.instance()->inputMethodEntry(ic) : nullptr;
+        auto addon = entry ? entry->addon() : "";
+        // HACK: VSCode terminal (xterm.js) can't type ， and 。, so replace
+        // com.apple.keylayout.ABC with com.apple.keylayout.PinyinKeyboard.
+        auto isChineseAddons = addon == "pinyin" || addon == "table";
+        auto isRime = addon == "rime";
+        if (isChineseAddons || isRime) {
+            auto imLayout = group.layoutFor(entry->uniqueName());
+            if (imLayout == "us" || (imLayout == "" && groupLayout == "us")) {
+                groupLayout =
+                    (isChineseAddons && fcitx::chinesePunctuation) ||
+                            (isRime && fcitx::rimePunctuation)
+                        ? "PinyinKeyboard"
+                        : "us" /* us is needed when group has us-dvorak and
+                                  pinyin has us on typing comma and period.
+                                */
+                    ;
+            }
+        }
+        pinyinKeyboard = groupLayout == "PinyinKeyboard";
+
+        return groupLayout;
     });
 }

--- a/macosfrontend/macosfrontend.h
+++ b/macosfrontend/macosfrontend.h
@@ -29,6 +29,10 @@ FCITX_CONFIG_ENUM_NAME_WITH_I18N(StatusBar, N_("Hidden"),
 
 namespace fcitx {
 
+extern bool chinesePunctuation;
+extern bool rimePunctuation;
+void overrideKeyboardLayoutAsync();
+
 class MacosInputContext;
 
 struct AppIMAnnotation {

--- a/macosfrontend/macosfrontend.swift
+++ b/macosfrontend/macosfrontend.swift
@@ -203,10 +203,13 @@ public func getSelection() -> String {
 // Call it on
 // 1. Open a new App: FcitxInputController.init
 // 2. Switch App: FcitxInputController.activateServer
-// 3. Switch group: InputMethodGroupChanged
+// 3. Switch group: condition covered by 4
+// (below are HACK for VSCode terminal and Neovide Chinese punctuation)
+// 4. Switch input method: InputContextInputMethodActivated
+// 5. Update punctuation option: UserInterfaceComponent::StatusArea
 public func overrideKeyboardLayout() {
   let layout = String(get_current_group_layout())
-  let appleLayout = layoutMap[layout] ?? "ABC"
+  let appleLayout = layout == "PinyinKeyboard" ? "PinyinKeyboard" : layoutMap[layout] ?? "ABC"
   FCITX_DEBUG("Override keyboard layout to \(appleLayout)")
   client?.overrideKeyboard(withKeyboardNamed: "com.apple.keylayout.\(appleLayout)")
 }

--- a/tests/testkey.cpp
+++ b/tests/testkey.cpp
@@ -16,6 +16,13 @@ void test_osx_to_fcitx() {
                                              NSEventModifierFlagShift |
                                                  NSEventModifierFlagOption,
                                              kVK_ANSI_1) == FcitxKey_exclam);
+    ::pinyinKeyboard = true;
+    FCITX_ASSERT(osx_unicode_to_fcitx_keysym(65292 /* ， */, 0,
+                                             kVK_ANSI_Comma) == FcitxKey_comma);
+    FCITX_ASSERT(
+        osx_unicode_to_fcitx_keysym(12299 /* 》 */, NSEventModifierFlagShift,
+                                    kVK_ANSI_Period) == FcitxKey_greater);
+    ::pinyinKeyboard = false;
 
     FCITX_ASSERT(osx_keycode_to_fcitx_keycode(kVK_ANSI_0) == 11 + 8);
     FCITX_ASSERT(osx_keycode_to_fcitx_keycode(kVK_ANSI_Keypad0) == 82 + 8);

--- a/webpanel/webpanel.cpp
+++ b/webpanel/webpanel.cpp
@@ -1,6 +1,8 @@
 #include <fcitx/inputpanel.h>
 
 #include "fcitx.h"
+#include "fcitx/action.h"
+#include "fcitx/userinterfacemanager.h"
 #include "../macosfrontend/macosfrontend.h"
 #include "config/config.h"
 #include "webpanel.h"
@@ -468,6 +470,33 @@ void WebPanel::update(UserInterfaceComponent component,
         break;
     }
     case UserInterfaceComponent::StatusArea:
+        auto &statusArea = inputContext->statusArea();
+        bool needUpdate = false;
+        for (auto *action : statusArea.allActions()) {
+            if (!action->id()) {
+                // Not registered with UI manager.
+                continue;
+            }
+            auto name = action->name();
+            if (name == "punctuation") {
+                auto icon = action->icon(inputContext);
+                chinesePunctuation = icon == "fcitx-punc-active";
+                needUpdate = true;
+            } else if (name.starts_with("fcitx-rime-") &&
+                       name.ends_with("-ascii_punct")) {
+                auto text = action->shortText(inputContext);
+                auto dotIndex = text.find("．");
+                auto enIndex = text.find("英");
+                rimePunctuation =
+                    dotIndex != std::string::npos &&
+                        text.find("。") < dotIndex ||
+                    enIndex != std::string::npos && text.find("中") < enIndex;
+                needUpdate = true;
+            }
+        }
+        if (needUpdate) {
+            overrideKeyboardLayoutAsync();
+        }
         // No need to implement.  MacOS will always try to fetch new
         // data, and we don't try to cache anything.
         break;


### PR DESCRIPTION
Mitigates #223. Not working for `"` or non-ABC layout.
 
It's xterm.js and other clients' bug for sure, but since people only see native Pinyin works, they expect others work as well. Hack before proper fixes land in apps.
We detect possible events that affect Chinese punctuations state in chinese-addons and rime, and when override keyboard layout after that, if we were to use com.apple.keylayout.ABC when Chinese punctuations are enabled, we use com.apple.keylayout.PinyinKeyboard instead.
This changes keysym received by app (our intent) and Fcitx5 (side effect), so we also map back to ASCII for engines.