### PR TITLE
fix status item position reset on update

### DIFF
--- a/assets/update.sh
+++ b/assets/update.sh
@@ -25,34 +25,4 @@ fi
 xattr -dr com.apple.quarantine "$APP_DIR"
 codesign --force --sign - --deep "$APP_DIR"
 
-cd "$RESOURCES_DIR"
-im=$(su -m "$user" -c "./get_im")
-# Switching out is necessary, otherwise it doesn't show menu
-# Not sure which one so try both.
-su -m "$user" -c "./switch_im com.apple.keylayout.ABC"
-su -m "$user" -c "./switch_im com.apple.keylayout.US"
 killall Fcitx5
-
-# This input source ID comes from Carbon API:
-# import Carbon
-
-# let bundleId = "org.fcitx.inputmethod.Fcitx5"
-# let conditions = NSMutableDictionary()
-# conditions.setValue(bundleId, forKey: kTISPropertyBundleID as String)
-# if let array = TISCreateInputSourceList(conditions, true)?.takeRetainedValue()
-#   as? [TISInputSource]
-# {
-#   for inputSource in array {
-#     if let ptr = TISGetInputSourceProperty(inputSource, kTISPropertyInputSourceID) {
-#       let inputSourceID = Unmanaged<CFString>.fromOpaque(ptr).takeUnretainedValue() as String
-#       print(inputSourceID)
-#     }
-#   }
-# }
-
-# The rule to construct seems:
-# org.fcitx.inputmethod.Fcitx5 is our CFBundleIdentifier;
-# The rest is the keys under tsInputModeListKey trimming the org.fcitx.inputmethod.
-
-# Switch back.
-su -m "$user" -c "./switch_im $im"

--- a/src/config/about.swift
+++ b/src/config/about.swift
@@ -371,15 +371,6 @@ struct AboutView: View {
 
   func install(debug: Bool) {
     viewModel.state = .installing
-    let conditions = NSMutableDictionary()
-    conditions.setValue("com.apple.keylayout.ABC", forKey: kTISPropertyInputSourceID as String)
-    if let array = TISCreateInputSourceList(conditions, true)?.takeRetainedValue()
-      as? [TISInputSource]
-    {
-      for inputSource in array {
-        TISSelectInputSource(inputSource)
-      }
-    }
     let path = cacheDir.appendingPathComponent(debug ? mainDebugFileName : mainFileName).localPath()
     // Necessary to put it in background, otherwise sudo UI will hang if it has been canceled once.
     Task {


### PR DESCRIPTION
The code removed doesn't seem to be needed as of today on macOS 26. Not sure if it's the project or system that fixed something.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the installation and restart process by removing unnecessary input-source switching.
  * Reduced interruptions to the active macOS input method during updates.
  * Preserved error reporting when installation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->